### PR TITLE
topic/grapito#58 menu text

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -27,8 +27,8 @@ class GrapitoConan(ConanFile):
         ("spdlog/1.9.2"),
 
         ("aunteater/e1602077f0@adnn/develop"),
-        ("graphics/7d6a8484e1@adnn/develop"),
-        ("math/8294e87cda@adnn/develop"),
+        ("graphics/82b4f8dcb3@adnn/develop"),
+        ("math/b0a941d6c0@adnn/develop"),
         ("websocket/1e3830b8b8@adnn/develop"),
     )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(app/grapkimbo)
 
 add_subdirectory(app/prototypes/grapito-splines)
+add_subdirectory(app/compilebox)

--- a/src/app/compilebox/CMakeLists.txt
+++ b/src/app/compilebox/CMakeLists.txt
@@ -1,0 +1,50 @@
+set(TARGET_NAME grapito_compilebox)
+
+
+set(${TARGET_NAME}_HEADERS
+)
+
+set(${TARGET_NAME}_SOURCES
+)
+
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR}
+             FILES ${${TARGET_NAME}_HEADERS} ${${TARGET_NAME}_SOURCES}
+)
+
+
+find_package(Aunteater CONFIG REQUIRED COMPONENTS aunteater)
+find_package(Graphics CONFIG REQUIRED COMPONENTS arte graphics resource)
+find_package(Math CONFIG REQUIRED COMPONENTS math)
+find_package(Websocket CONFIG REQUIRED COMPONENTS websocket)
+
+add_executable(${TARGET_NAME}
+    ${${TARGET_NAME}_SOURCES}
+    ${${TARGET_NAME}_HEADERS}
+    main.cpp
+)
+
+target_include_directories(${TARGET_NAME}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${TARGET_NAME}
+    PRIVATE
+        ad::arte
+        ad::aunteater
+        ad::graphics
+        ad::math
+        ad::resource
+        ad::websocket
+)
+
+
+set_target_properties(${TARGET_NAME} PROPERTIES
+                      VERSION "${${PROJECT_NAME}_VERSION}"
+)
+
+
+##
+## Install
+##
+
+install(TARGETS ${TARGET_NAME})

--- a/src/app/compilebox/main.cpp
+++ b/src/app/compilebox/main.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+    return 0;
+}

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -45,9 +45,9 @@ namespace menu
 {
     constexpr int gBlurringPasses = 6;
     constexpr float gViewedHeight = 1000.f;
-    constexpr math::Size<2, GLfloat> gButtonSize{320.f, 80.f};
+    constexpr math::Size<2, GLfloat> gButtonSize{360.f, 80.f};
     constexpr char * gFont{"fonts/dejavu-fonts-ttf-2.37/DejaVuSans.ttf"};
-    constexpr GLfloat gTextHeight = 0.75f * gButtonSize.height();
+    constexpr GLfloat gTextHeight = 0.65f * gButtonSize.height();
     constexpr float gButtonSpacing = 100.f;
     constexpr math::sdr::Rgb gButtonColor{ 120, 100, 110 };
     constexpr math::sdr::Rgb gSelectedColor{ 190, 190, 80 };

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -46,7 +46,7 @@ namespace menu
     constexpr int gBlurringPasses = 6;
     constexpr float gViewedHeight = 1000.f;
     constexpr math::Size<2, GLfloat> gButtonSize{360.f, 80.f};
-    constexpr char * gFont{"fonts/dejavu-fonts-ttf-2.37/DejaVuSans.ttf"};
+    constexpr char * gFont = "fonts/dejavu-fonts-ttf-2.37/ttf/DejaVuSans.ttf";
     constexpr GLfloat gTextHeight = 0.65f * gButtonSize.height();
     constexpr float gButtonSpacing = 100.f;
     constexpr math::sdr::Rgb gButtonColor{ 120, 100, 110 };

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -46,6 +46,8 @@ namespace menu
     constexpr int gBlurringPasses = 6;
     constexpr float gViewedHeight = 1000.f;
     constexpr math::Size<2, GLfloat> gButtonSize{320.f, 80.f};
+    constexpr char * gFont{"fonts/dejavu-fonts-ttf-2.37/DejaVuSans.ttf"};
+    constexpr GLfloat gTextHeight = 0.75f * gButtonSize.height();
     constexpr float gButtonSpacing = 100.f;
     constexpr math::sdr::Rgb gButtonColor{ 120, 100, 110 };
     constexpr math::sdr::Rgb gSelectedColor{ 190, 190, 80 };

--- a/src/app/grapkimbo/Scenery/GameScene.cpp
+++ b/src/app/grapkimbo/Scenery/GameScene.cpp
@@ -11,8 +11,10 @@ namespace ad {
 namespace grapito {
 
 
-GameScene::GameScene(std::shared_ptr<graphics::AppInterface> aAppInterface) :
-    mAppInterface{std::move(aAppInterface)}
+GameScene::GameScene(std::shared_ptr<resource::ResourceManager> aResources,
+                     std::shared_ptr<graphics::AppInterface> aAppInterface) :
+    mAppInterface{std::move(aAppInterface)},
+    mResources{std::move(aResources)}
 {}
 
 
@@ -24,7 +26,7 @@ UpdateStatus GameScene::update(
     InputState gamePause = aInputs.get(Controller::Keyboard)[Command::Start];
     if (gamePause.positiveEdge())
     {
-        aStateMachine.pushState(setupPauseMenu(mAppInterface, shared_from_this()));
+        aStateMachine.pushState(setupPauseMenu(mResources, mAppInterface, shared_from_this()));
         // Causes troubles with detection of next press of pause button
         // it would still be the same edge!
         //return aStateMachine.update(aTimer, aInputs);

--- a/src/app/grapkimbo/Scenery/GameScene.h
+++ b/src/app/grapkimbo/Scenery/GameScene.h
@@ -7,6 +7,8 @@
 
 #include <graphics/AppInterface.h>
 
+#include <resource/ResourceManager.h>
+
 #include <memory>
 
 
@@ -17,7 +19,8 @@ namespace grapito {
 class GameScene : public State, public std::enable_shared_from_this<GameScene>
 {
 public:
-    GameScene(std::shared_ptr<graphics::AppInterface> aAppInterface);
+    GameScene(std::shared_ptr<resource::ResourceManager> aResources,
+              std::shared_ptr<graphics::AppInterface> aAppInterface);
 
     UpdateStatus update(
         GrapitoTimer & aTimer,
@@ -36,6 +39,7 @@ protected:
 
 private:
     TimeSystemsUpdater mUpdater;
+    std::shared_ptr<resource::ResourceManager> mResources;
 }; 
 
 

--- a/src/app/grapkimbo/Scenery/MenuScene.cpp
+++ b/src/app/grapkimbo/Scenery/MenuScene.cpp
@@ -113,10 +113,18 @@ void MenuScene::renderMenu()
     mStrings.clear();
     for (std::size_t buttonId = 0; buttonId != mMenu.size(); ++buttonId)
     {
-        mTexting.prepareString(mMenu[buttonId].mText, {0.f, buttonY}, mStrings);
-        debugDrawer->drawOutline(mTexting.getStringBounds(mMenu[buttonId].mText, {0.f, buttonY}));
+        math::Position<2, GLfloat> buttonCenter{0.f, buttonY};
+
+        math::Rectangle<GLfloat> textBoundingBox =
+            mTexting.getStringBounds(mMenu[buttonId].mText, { 0.f, 0.f });
+        // The offset from the center of the bounding box to the initial pen position (origin)
+        math::Vec<2, GLfloat> centeringPenOffset = -textBoundingBox.center().as<math::Vec>();
+        mTexting.prepareString(mMenu[buttonId].mText, buttonCenter + centeringPenOffset, mStrings);
+        debugDrawer->drawOutline(
+            mTexting.getStringBounds(mMenu[buttonId].mText, buttonCenter + centeringPenOffset));
+
         mShaping.addRectangle({
-            Rectangle{ {0.f, buttonY}, menu::gButtonSize }.centered(),
+            Rectangle{ buttonCenter , menu::gButtonSize }.centered(),
             buttonId == mMenu.mSelected ? menu::gSelectedColor : menu::gButtonColor });
         buttonY -= incrementY;
     }

--- a/src/app/grapkimbo/Scenery/MenuScene.cpp
+++ b/src/app/grapkimbo/Scenery/MenuScene.cpp
@@ -10,6 +10,8 @@
 
 #include <graphics/CameraUtilities.h>
 
+#include <resource/PathProvider.h>
+
 
 namespace ad {
 namespace grapito {
@@ -32,6 +34,7 @@ MenuScene::MenuScene(Menu aMenu,
     mOptionalGameScene{aGameScene},
     mRenderEffect{mAppInterface},
     mShaping{mAppInterface->getFramebufferSize()},
+    mTexting{resource::pathFor(menu::gFont), menu::gTextHeight, menu::gViewedHeight, mAppInterface},
     // Useless, it is setup before transitions. But there is no default ctor.
     mMenuXPosition{makeInterpolation(mAppInterface, 0.f, 0.f)} 
 {}
@@ -104,14 +107,18 @@ void MenuScene::renderMenu()
     GLfloat buttonY = menuHeight / 2.f - menu::gButtonSize.height() / 2.f;
     GLfloat incrementY = menu::gButtonSize.height() + menu::gButtonSpacing;
 
+    mStrings.clear();
     for (std::size_t buttonId = 0; buttonId != mMenu.size(); ++buttonId)
     {
+        mTexting.prepareString(mMenu[buttonId].mText, {0.f, buttonY}, mStrings);
         mShaping.addRectangle({
             Rectangle{ {0.f, buttonY}, menu::gButtonSize }.centered(),
             buttonId == mMenu.mSelected ? menu::gSelectedColor : menu::gButtonColor });
         buttonY -= incrementY;
     }
+    mTexting.updateInstances(mStrings);
     mShaping.render();
+    mTexting.render();
 }
 
 

--- a/src/app/grapkimbo/Scenery/MenuScene.cpp
+++ b/src/app/grapkimbo/Scenery/MenuScene.cpp
@@ -12,8 +12,6 @@
 
 #include <graphics/CameraUtilities.h>
 
-#include <resource/PathProvider.h>
-
 
 namespace ad {
 namespace grapito {
@@ -29,6 +27,7 @@ auto makeInterpolation(std::shared_ptr<graphics::AppInterface> aAppInterface, GL
 }
 
 MenuScene::MenuScene(Menu aMenu,
+                     const filesystem::path & aFontPath,
                      std::shared_ptr<graphics::AppInterface> aAppInterface,
                      std::shared_ptr<GameScene> aGameScene) :
     mMenu{std::move(aMenu)},
@@ -36,7 +35,7 @@ MenuScene::MenuScene(Menu aMenu,
     mOptionalGameScene{aGameScene},
     mRenderEffect{mAppInterface},
     mShaping{mAppInterface->getFramebufferSize()},
-    mTexting{resource::pathFor(menu::gFont), menu::gTextHeight, menu::gViewedHeight, mAppInterface},
+    mTexting{aFontPath, menu::gTextHeight, menu::gViewedHeight, mAppInterface},
     // Useless, it is setup before transitions. But there is no default ctor.
     mMenuXPosition{makeInterpolation(mAppInterface, 0.f, 0.f)} 
 {

--- a/src/app/grapkimbo/Scenery/MenuScene.cpp
+++ b/src/app/grapkimbo/Scenery/MenuScene.cpp
@@ -6,6 +6,8 @@
 #include "../Configuration.h"
 #include "../Logging.h"
 
+#include "../Utils/DrawDebugStuff.h"
+
 #include <math/VectorUtilities.h>
 
 #include <graphics/CameraUtilities.h>
@@ -84,6 +86,7 @@ std::pair<TransitionProgress, UpdateStatus> MenuScene::scrollMenu(GrapitoTimer &
     Rectangle viewed = graphics::getViewRectangle(mAppInterface->getFramebufferSize(), menu::gViewedHeight);
     viewed.origin().x() = mMenuXPosition.advance(aTimer.delta());
     setViewedRectangle(mShaping, viewed);
+    debugDrawer->setViewedRectangle(viewed);
     renderMenu();
 
     return {
@@ -111,6 +114,7 @@ void MenuScene::renderMenu()
     for (std::size_t buttonId = 0; buttonId != mMenu.size(); ++buttonId)
     {
         mTexting.prepareString(mMenu[buttonId].mText, {0.f, buttonY}, mStrings);
+        debugDrawer->drawOutline(mTexting.getStringBounds(mMenu[buttonId].mText, {0.f, buttonY}));
         mShaping.addRectangle({
             Rectangle{ {0.f, buttonY}, menu::gButtonSize }.centered(),
             buttonId == mMenu.mSelected ? menu::gSelectedColor : menu::gButtonColor });

--- a/src/app/grapkimbo/Scenery/MenuScene.h
+++ b/src/app/grapkimbo/Scenery/MenuScene.h
@@ -80,6 +80,11 @@ public:
 
 private:
     std::pair<TransitionProgress, UpdateStatus> scrollMenu(GrapitoTimer & aTimer);
+
+    /// \brief Generate menu geometry and fonts, and update all vertex buffers of renderers.
+    void updateMenuBuffers();
+
+    /// \brief Have renderers draw the menu to screen.
     void renderMenu();
 
     Menu mMenu;
@@ -92,7 +97,6 @@ private:
     RenderEffect mRenderEffect;
     graphics::TrivialShaping mShaping;
     graphics::Texting mTexting;
-    graphics::Texting::Mapping mStrings;
     math::Interpolation<
         GLfloat,
         GrapitoTimer::Value_t,

--- a/src/app/grapkimbo/Scenery/MenuScene.h
+++ b/src/app/grapkimbo/Scenery/MenuScene.h
@@ -6,6 +6,7 @@
 #include "../Utils/RenderEffect.h"
 
 #include <graphics/AppInterface.h>
+#include <graphics/Texting.h>
 #include <graphics/TrivialShaping.h>
 
 #include <math/Interpolation.h>
@@ -36,6 +37,11 @@ struct Menu
 
     auto size() const
     { return mButtons.size(); }
+
+    UiButton & operator[](std::size_t aButtonIndex)
+    {
+        return mButtons[aButtonIndex];
+    }
 
     std::vector<UiButton> mButtons;
     std::vector<UiButton>::size_type mSelected = 0;
@@ -85,6 +91,8 @@ private:
     std::shared_ptr<GameScene> mOptionalGameScene; 
     RenderEffect mRenderEffect;
     graphics::TrivialShaping mShaping;
+    graphics::Texting mTexting;
+    graphics::Texting::Mapping mStrings;
     math::Interpolation<
         GLfloat,
         GrapitoTimer::Value_t,

--- a/src/app/grapkimbo/Scenery/MenuScene.h
+++ b/src/app/grapkimbo/Scenery/MenuScene.h
@@ -55,6 +55,7 @@ class MenuScene : public State
 {
 public:
     MenuScene(Menu aMenu,
+              const filesystem::path & aFontPath,
               std::shared_ptr<graphics::AppInterface> aAppInterface,
               std::shared_ptr<GameScene> aGameScene = nullptr);
 

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -27,8 +27,9 @@ namespace ad {
 namespace grapito {
 
 
-RopeGame::RopeGame(std::shared_ptr<graphics::AppInterface> aAppInterface) :
-    GameScene{std::move(aAppInterface)}
+RopeGame::RopeGame(std::shared_ptr<resource::ResourceManager> aResources,
+                   std::shared_ptr<graphics::AppInterface> aAppInterface) :
+    GameScene{std::move(aResources), std::move(aAppInterface)}
 {
     mSystemManager.add<LevelGeneration>();
     mSystemManager.add<Control>();

--- a/src/app/grapkimbo/Scenery/RopeGame.h
+++ b/src/app/grapkimbo/Scenery/RopeGame.h
@@ -12,7 +12,8 @@ class Render;
 class RopeGame : public GameScene
 {
 public:
-    RopeGame(std::shared_ptr<graphics::AppInterface> aAppInterface);
+    RopeGame(std::shared_ptr<resource::ResourceManager> aResources,
+             std::shared_ptr<graphics::AppInterface> aAppInterface);
 
     void render() const override;
 

--- a/src/app/grapkimbo/Systems/Render.cpp
+++ b/src/app/grapkimbo/Systems/Render.cpp
@@ -31,7 +31,6 @@ void Render::update(const GrapitoTimer, const GameInputState &)
 {
     mTrivialShaping.clearShapes();
     mTrivialLineStrip.clearLines();
-    debugDrawer->clear();
     mAppInterface->clear();
 
     for (auto & [geometry, body, visualRectangle] : mBodyRectangles)
@@ -83,8 +82,7 @@ void Render::update(const GrapitoTimer, const GameInputState &)
         setOrthographicView(mCurving,
                             {geometry.position, 0.f},
                             graphics::getViewVolume(mAppInterface->getWindowSize(), render::gViewedHeight, 1.f, 2.f));
-        setViewedRectangle(debugDrawer->mTrivialShaping, viewed);
-        setViewedRectangle(debugDrawer->mTrivialLineStrip, viewed);
+        debugDrawer->setViewedRectangle(viewed);
     }
 
     render();
@@ -96,7 +94,6 @@ void Render::render() const
     mTrivialLineStrip.render();
     mTrivialShaping.render();
     mCurving.render(mBeziers);
-    debugDrawer->render();
 }
 
 } // namespace grapito

--- a/src/app/grapkimbo/Systems/Render.cpp
+++ b/src/app/grapkimbo/Systems/Render.cpp
@@ -29,7 +29,6 @@ Render::Render(aunteater::EntityManager & aEntityManager,
 
 void Render::update(const GrapitoTimer, const GameInputState &)
 {
-    mTrivialShaping.clearShapes();
     mTrivialLineStrip.clearLines();
     mAppInterface->clear();
 
@@ -40,11 +39,12 @@ void Render::update(const GrapitoTimer, const GameInputState &)
         );
     }
 
+    std::vector<graphics::TrivialShaping::Rectangle> shapes;
     for(const auto [geometry, visualRectangle] : mRectangles)
     {
         // TODO should control drawing of Scope::RopeStructure rectangles
         // based on Imgui widgets.
-        mTrivialShaping.addRectangle({
+        shapes.push_back({
             {
                 static_cast<math::Position<2, GLfloat>>(geometry.position),
                 static_cast<math::Size<2, GLfloat>>(geometry.dimension)  
@@ -53,6 +53,7 @@ void Render::update(const GrapitoTimer, const GameInputState &)
             visualRectangle.transform,
         });
     }
+    mTrivialShaping.updateInstances(shapes);
 
     for(const auto [geometry, visualOutline] : mOutlines)
     {

--- a/src/app/grapkimbo/Systems/Render.cpp
+++ b/src/app/grapkimbo/Systems/Render.cpp
@@ -53,6 +53,7 @@ void Render::update(const GrapitoTimer, const GameInputState &)
         );
     }
 
+    // shapes vector to receive all rectangle to be drawn by TrivialShaping renderer.
     std::vector<graphics::TrivialShaping::Rectangle> shapes;
     for(const auto [geometry, visualRectangle] : mRectangles)
     {
@@ -67,7 +68,6 @@ void Render::update(const GrapitoTimer, const GameInputState &)
             visualRectangle.transform,
         });
     }
-    mTrivialShaping.updateInstances(shapes);
 
     for(const auto [geometry, visualPolygon] : mPolygons)
     {
@@ -104,7 +104,7 @@ void Render::update(const GrapitoTimer, const GameInputState &)
 
     for (const auto & [geometry, body, data] : mCrosshairs)
     {
-        mTrivialShaping.addRectangle({
+        shapes.push_back({
                 {
                     static_cast<math::Position<2, GLfloat>>(geometry.position + body.massCenter.as<math::Vec>() + data.mAimVector * 5.f - Vec2{0.25f, 0.25f}),
                     {0.5f, 0.5f}
@@ -138,6 +138,7 @@ void Render::update(const GrapitoTimer, const GameInputState &)
         debugDrawer->setViewedRectangle(viewed);
     }
 
+    mTrivialShaping.updateInstances(shapes);
     render();
 }
 

--- a/src/app/grapkimbo/TopLevelStates.cpp
+++ b/src/app/grapkimbo/TopLevelStates.cpp
@@ -59,15 +59,16 @@ std::shared_ptr<SplashScene> setupSplashScreen(math::Size<2, int> aResolution,
 }
 
 
-std::shared_ptr<MenuScene> setupMainMenu(std::shared_ptr<graphics::AppInterface> aAppInterface)
+std::shared_ptr<MenuScene> setupMainMenu(const std::shared_ptr<resource::ResourceManager> & aResources,
+                                         std::shared_ptr<graphics::AppInterface> aAppInterface)
 {
     return std::make_shared<MenuScene>(
         Menu {
             std::vector<UiButton>{
                 { "Start",
-                  [](StateMachine & aMachine, std::shared_ptr<graphics::AppInterface> & aAppInterface)
+                  [aResources](StateMachine & aMachine, std::shared_ptr<graphics::AppInterface> & aAppInterface)
                     {
-                        aMachine.emplaceState<RopeGame>(aAppInterface);
+                        aMachine.emplaceState<RopeGame>(aResources, aAppInterface);
                     }
                 },
                 { "Drop Grapple",
@@ -78,10 +79,13 @@ std::shared_ptr<MenuScene> setupMainMenu(std::shared_ptr<graphics::AppInterface>
                 },
             },
         },
+        aResources->pathFor(menu::gFont),
         std::move(aAppInterface));
 }
 
+
 std::shared_ptr<MenuScene> setupPauseMenu(
+    const std::shared_ptr<resource::ResourceManager> & aResources,
     std::shared_ptr<graphics::AppInterface> & aAppInterface,
     std::shared_ptr<GameScene> aGameScene)
 {
@@ -95,11 +99,11 @@ std::shared_ptr<MenuScene> setupPauseMenu(
                     }
                 },
                 { "Restart",
-                  [](StateMachine & aMachine, std::shared_ptr<graphics::AppInterface> & aAppInterface)
+                  [aResources](StateMachine & aMachine, std::shared_ptr<graphics::AppInterface> & aAppInterface)
                     {
                         aMachine.popState(); // this
                         aMachine.popState(); // running game
-                        aMachine.emplaceState<RopeGame>(aAppInterface); // new game
+                        aMachine.emplaceState<RopeGame>(aResources, aAppInterface); // new game
                     }
                 },
                 { "Main Menu",
@@ -111,6 +115,7 @@ std::shared_ptr<MenuScene> setupPauseMenu(
                 },
             },
         },
+        aResources->pathFor(menu::gFont),
         aAppInterface,
         std::move(aGameScene)
     );

--- a/src/app/grapkimbo/TopLevelStates.cpp
+++ b/src/app/grapkimbo/TopLevelStates.cpp
@@ -64,13 +64,13 @@ std::shared_ptr<MenuScene> setupMainMenu(std::shared_ptr<graphics::AppInterface>
     return std::make_shared<MenuScene>(
         Menu {
             std::vector<UiButton>{
-                { "Start Playing",
+                { "Start",
                   [](StateMachine & aMachine, std::shared_ptr<graphics::AppInterface> & aAppInterface)
                     {
                         aMachine.emplaceState<RopeGame>(aAppInterface);
                     }
                 },
-                { "Drop your Grapple",
+                { "Drop Grapple",
                   [](StateMachine & aMachine, std::shared_ptr<graphics::AppInterface> & aAppInterface)
                     {
                         aAppInterface->requestCloseApplication();
@@ -94,7 +94,7 @@ std::shared_ptr<MenuScene> setupPauseMenu(
                         aMachine.popState(); // this
                     }
                 },
-                { "Restart level",
+                { "Restart",
                   [](StateMachine & aMachine, std::shared_ptr<graphics::AppInterface> & aAppInterface)
                     {
                         aMachine.popState(); // this
@@ -102,7 +102,7 @@ std::shared_ptr<MenuScene> setupPauseMenu(
                         aMachine.emplaceState<RopeGame>(aAppInterface); // new game
                     }
                 },
-                { "Exit to Main Menu",
+                { "Main Menu",
                   [](StateMachine & aMachine, std::shared_ptr<graphics::AppInterface> & aAppInterface)
                     {
                         aMachine.popState(); // this

--- a/src/app/grapkimbo/TopLevelStates.h
+++ b/src/app/grapkimbo/TopLevelStates.h
@@ -19,10 +19,13 @@ std::shared_ptr<SplashScene> setupSplashScreen(math::Size<2, int> aResolution,
                                                const resource::ResourceManager & aResources);
 
 
-std::shared_ptr<MenuScene> setupMainMenu(std::shared_ptr<graphics::AppInterface> aAppInterface);
-
+std::shared_ptr<MenuScene> setupMainMenu(const std::shared_ptr<resource::ResourceManager> & aResources,
+                                         std::shared_ptr<graphics::AppInterface> aAppInterface);
+    
+    
 
 std::shared_ptr<MenuScene> setupPauseMenu(
+    const std::shared_ptr<resource::ResourceManager> & aResources,
     std::shared_ptr<graphics::AppInterface> & aAppInterface,
     std::shared_ptr<GameScene> aGameScene);
 

--- a/src/app/grapkimbo/Utils/DrawDebugStuff.cpp
+++ b/src/app/grapkimbo/Utils/DrawDebugStuff.cpp
@@ -55,9 +55,11 @@ namespace ad
                 return;
             }
 
+            std::vector<graphics::TrivialShaping::Rectangle> rectangles;
             for (auto rectangle : mRectangles)
             {
-                mTrivialShaping.addRectangle(
+                // TODO this should probably be the data member type, instead of having yet another triangle type.
+                rectangles.push_back(
                     {
                         {
                             rectangle.origin,
@@ -68,6 +70,7 @@ namespace ad
                     }
                 );
             }
+            mTrivialShaping.updateInstances(rectangles);
 
             for (auto line : mLines)
             {
@@ -103,7 +106,6 @@ namespace ad
 
         void DrawDebugStuff::clear()
         {
-            mTrivialShaping.clearShapes();
             mTrivialLineStrip.clearLines();
         }
     }

--- a/src/app/grapkimbo/Utils/DrawDebugStuff.h
+++ b/src/app/grapkimbo/Utils/DrawDebugStuff.h
@@ -3,6 +3,7 @@
 #include "commons.h"
 
 #include <graphics/ApplicationGlfw.h>
+#include <graphics/CameraUtilities.h>
 #include <graphics/commons.h>
 #include <graphics/TrivialLineStrip.h>
 #include <graphics/TrivialShaping.h>
@@ -18,6 +19,16 @@ namespace ad
     {
         struct Rectangle
         {
+            /* implicit */
+            Rectangle(math::Rectangle<GLfloat> aRectangle,
+                      const math::sdr::Rgb & aColor = math::sdr::gGreen,
+                      const math::Matrix<3, 3> aTransform = math::Matrix<3, 3>::Identity()) :
+                origin{aRectangle.origin()},
+                dimension{aRectangle.dimension()},
+                transform{aTransform},
+                color{aColor}
+            {}
+
             Rectangle(
                 const grapito::Position2 & aOrigin,
                 const math::Size<2, float> & aDimension,
@@ -100,6 +111,7 @@ namespace ad
                     mTrivialShaping{aApplication.getAppInterface()->getWindowSize()},
                     mTrivialLineStrip{aApplication.getAppInterface()->getWindowSize()}
                 {}
+                // RFP I think overloading could be enough here (i.e. only draw() and drawOutline() methods)
                 void drawRectangle(Rectangle aRectangle);
                 void drawOutline(Rectangle aRectangle);
                 void drawLine(Line aLine);
@@ -108,6 +120,13 @@ namespace ad
                 //void drawPoint(Point aPoint);
                 void render();
                 void clear();
+
+                void setViewedRectangle(math::Rectangle<GLfloat> aViewedRectangle)
+                {
+                    graphics::setViewedRectangle(mTrivialShaping, aViewedRectangle);
+                    graphics::setViewedRectangle(mTrivialLineStrip, aViewedRectangle);
+                }
+
                 graphics::TrivialShaping mTrivialShaping;
                 graphics::TrivialLineStrip mTrivialLineStrip;
 

--- a/src/app/grapkimbo/main.cpp
+++ b/src/app/grapkimbo/main.cpp
@@ -44,15 +44,16 @@ int main(int /*argc*/, const char ** /*argv*/)
         ad::grapito::ImguiState imguiState;
         DebugUI debugUI;
 
-        resource::ResourceManager resources{gRepositoryRoot / filesystem::path{"../grapito_media/assets/"}};
+        std::shared_ptr<resource::ResourceManager> resources =
+            std::make_shared<resource::ResourceManager>(gRepositoryRoot / filesystem::path{"../grapito_media/assets/"});
 
         // The splashscreens are the initial state
         // note: coordinates are used for window proportions
         StateMachine topLevelFlow{setupSplashScreen(application.getAppInterface()->getWindowSize(),
-                                                    resources)};
+                                                    *resources)};
 
         // The next state in the stack is the main menu
-        topLevelFlow.putNext(setupMainMenu(application.getAppInterface()));
+        topLevelFlow.putNext(setupMainMenu(resources, application.getAppInterface()));
 
         GrapitoTimer timer{static_cast<float>(glfwGetTime())};
         GameInputState inputState;

--- a/src/app/grapkimbo/main.cpp
+++ b/src/app/grapkimbo/main.cpp
@@ -59,12 +59,14 @@ int main(int /*argc*/, const char ** /*argv*/)
 
         while(application.handleEvents())
         {
+            debugDrawer->clear();
             inputState.readAll(application);
             timer.mark((float)glfwGetTime());
             if (topLevelFlow.update(timer, inputState) == UpdateStatus::SwapBuffers)
             {
                 drawImGui(application, debugUI, imguiState);
                 renderImGui();
+                debugDrawer->render();
                 application.swapBuffers();
             }
         }


### PR DESCRIPTION
close #58

- Add text rendering to menus (naively recompute strings each frame).
- Move DrawDebugStuff out of Render system, show the text bounding boxes.
- Add a dummy "compilebox" app target, as a code sandbox.
- Center text in menu buttons.
- Adapt to the revisited TrivialShaping, limit MenuScene buffer updates.
