### PR TITLE
topic/grapito#83 c++20

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -21,9 +21,11 @@ jobs:
     name: Build, test, deploy
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-11]
+        cppstd: [20]
         include:
-          - cppstd: 17
+          - os: ubuntu-latest
+            gccversion: 10
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,6 +34,12 @@ jobs:
       # see: https://github.com/conan-io/conan-package-tools/issues/192
       # see: https://docs.conan.io/en/latest/faq/using.html?highlight=crlf#packages-got-outdated-when-uploading-an-unchanged-recipe-from-a-different-machine
       - run: git config --global core.autocrlf input
+
+      - name: Select GCC version.
+        if: runner.os == 'Linux'
+        run: |
+          echo "CC=gcc-${{ matrix.gccversion }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.gccversion }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -21,7 +21,10 @@ jobs:
     name: Build, test, deploy
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-11]
+        # Disable macos while spdlog crashes its compiler
+        # see: https://github.com/conan-io/conan-center-index/issues/8480
+        #os: [ubuntu-latest, windows-latest, macos-11]
+        os: [ubuntu-latest, windows-latest]
         cppstd: [20]
         include:
           - os: ubuntu-latest

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -26,10 +26,10 @@ class GrapitoConan(ConanFile):
         ("imgui/1.84.2"),
         ("spdlog/1.9.2"),
 
-        ("aunteater/3e3e95d669@adnn/develop"),
-        ("graphics/8435021739@adnn/develop"),
-        ("math/5d133d9943@adnn/develop"),
-        ("websocket/aa1006e3ff@adnn/develop"),
+        ("aunteater/9cd7bd9340@adnn/develop"),
+        ("graphics/d2b9318921@adnn/develop"),
+        ("math/017e7c42bf@adnn/develop"),
+        ("websocket/ef5d5bf4d9@adnn/develop"),
     )
 
     generators = "cmake_paths", "cmake_find_package", "CMakeToolchain"

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -54,14 +54,11 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
     mRenderSystem = mSystemManager.add<Render>(mAppInterface); 
 
     { // Load sprite animations
-        // Note: It is not obvious that it is better to maintain a permanent instance of the sprite sheet
+        // Note: It is not obvious whether it is better to maintain a permanent instance of the sprite sheet
         // (trading RAM for better load times), but this is a good pretext to use the ResourceManager.
         auto spriteSheets = {
-            // TODO C++20 should work with reference wrappers.
-            //std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/idle.json")),
-            //std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/run.json")),
-            mContext->loadAnimationSpriteSheet("sprite_sheet/idle.json"),
-            mContext->loadAnimationSpriteSheet("sprite_sheet/run.json"),
+            std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/idle.json")),
+            std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/run.json")),
         };
 
         graphics::sprite::Animator animator;


### PR DESCRIPTION
closes #83

- RopeGame reference-wrap SpriteSheet instead of making copies.
- [gh actions] Upgrade to c++20, gcc-10 and macos-11.
- [conan] Update references to internal dependencies (ported to C++20).
- [gh actions] Disable macos-11 (because of spdlog compiler crash).
