### PR TITLE
topic/grapito#85 game mode outline

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -28,7 +28,7 @@ class GrapitoConan(ConanFile):
         ("spdlog/1.9.2"),
 
         ("aunteater/9cd7bd9340@adnn/develop"),
-        ("graphics/d2b9318921@adnn/develop"),
+        ("graphics/b100c3e84d@adnn/develop"),
         ("math/017e7c42bf@adnn/develop"),
         ("websocket/ef5d5bf4d9@adnn/develop"),
     )

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -22,6 +22,7 @@ class GrapitoConan(ConanFile):
     }
 
     requires = (
+        ("boost/1.77.0"),
         ("glad/0.1.34"),
         ("imgui/1.84.2"),
         ("spdlog/1.9.2"),

--- a/src/app/grapkimbo/CMakeLists.txt
+++ b/src/app/grapkimbo/CMakeLists.txt
@@ -35,6 +35,8 @@ set(${TARGET_NAME}_HEADERS
     Components/PlayerData.h
     Components/Position.h
     Components/RopeCreator.h
+    Components/ScreenPosition.h
+    Components/Text.h
     Components/VisualOutline.h
     Components/VisualPolygon.h
     Components/VisualRectangle.h
@@ -55,6 +57,7 @@ set(${TARGET_NAME}_HEADERS
     Systems/GrappleCleanup.h
     Systems/GrappleJointCreator.h
     Systems/Gravity.h
+    Systems/Hud.h
     Systems/LevelGeneration.h
     Systems/Render.h
     Systems/AccelSolver.h
@@ -117,6 +120,7 @@ set(${TARGET_NAME}_SOURCES
     Systems/Gravity.cpp
     Systems/GrappleCleanup.cpp
     Systems/GrappleJointCreator.cpp
+    Systems/Hud.cpp
     Systems/LevelGeneration.cpp
     Systems/Render.cpp
     Systems/AccelSolver.cpp

--- a/src/app/grapkimbo/CMakeLists.txt
+++ b/src/app/grapkimbo/CMakeLists.txt
@@ -40,6 +40,8 @@ set(${TARGET_NAME}_HEADERS
     Components/VisualSprite.h
     Components/WeldJoint.h
 
+    Components/Debug/DirectControlTag.h
+
     Context/Context.h
     Context/Localization.h
     Context/Resources.h
@@ -56,6 +58,8 @@ set(${TARGET_NAME}_HEADERS
     Systems/Physics.h
     Systems/RopeCreation.h
     Systems/TransitionAnimationState.h
+
+    Systems/Debug/DirectControl.h
 
     TestScenes/CollisionTest.h
     TestScenes/DistanceTest.h
@@ -114,6 +118,8 @@ set(${TARGET_NAME}_SOURCES
     Systems/Physics.cpp
     Systems/RopeCreation.cpp
     Systems/TransitionAnimationState.cpp
+
+    Systems/Debug/DirectControl.cpp
 
     TestScenes/CollisionTest.cpp
     TestScenes/DistanceTest.cpp

--- a/src/app/grapkimbo/CMakeLists.txt
+++ b/src/app/grapkimbo/CMakeLists.txt
@@ -50,6 +50,8 @@ set(${TARGET_NAME}_HEADERS
     Systems/CameraGuidedControl.h
     Systems/Control.h
     Systems/DelayDeleter.h
+    Systems/GameRule.h
+    Systems/Gravity.h
     Systems/GrappleCleanup.h
     Systems/GrappleJointCreator.h
     Systems/Gravity.h
@@ -111,6 +113,7 @@ set(${TARGET_NAME}_SOURCES
     Systems/CameraGuidedControl.cpp
     Systems/Control.cpp
     Systems/DelayDeleter.cpp
+    Systems/GameRule.cpp
     Systems/Gravity.cpp
     Systems/GrappleCleanup.cpp
     Systems/GrappleJointCreator.cpp

--- a/src/app/grapkimbo/CMakeLists.txt
+++ b/src/app/grapkimbo/CMakeLists.txt
@@ -147,6 +147,7 @@ find_package(Graphics CONFIG REQUIRED COMPONENTS arte graphics resource)
 find_package(Math CONFIG REQUIRED COMPONENTS math)
 find_package(Websocket CONFIG REQUIRED COMPONENTS websocket)
 
+find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(glad REQUIRED)
 find_package(imgui REQUIRED)
 find_package(spdlog REQUIRED)
@@ -191,6 +192,7 @@ target_link_libraries(${TARGET_NAME}
         ad::resource
         ad::websocket
 
+        Boost::program_options
         glad::glad
         imgui::imgui
         spdlog::libspdlog

--- a/src/app/grapkimbo/CMakeLists.txt
+++ b/src/app/grapkimbo/CMakeLists.txt
@@ -24,6 +24,7 @@ set(${TARGET_NAME}_HEADERS
     Components/AnimatedSprite.h
     Components/Body.h
     Components/CameraGuide.h
+    Components/CameraLimits.h
     Components/CameraTag.h
     Components/Controllable.h
     Components/DelayDeletion.h
@@ -77,6 +78,7 @@ set(${TARGET_NAME}_HEADERS
     Scenery/SplashScene.h
     Scenery/StateMachine.h
 
+    Utils/Camera.h
     Utils/CollisionBox.h
     Utils/CompositeTransition.h
     Utils/DrawDebugStuff.h

--- a/src/app/grapkimbo/Components/CameraGuide.h
+++ b/src/app/grapkimbo/Components/CameraGuide.h
@@ -21,7 +21,8 @@ struct CameraGuide : public aunteater::Component<CameraGuide>
 
     enum class OnCompletion
     {
-        Remove,
+        RemoveComponent,
+        RemoveEntity,
         Keep,
     };
 

--- a/src/app/grapkimbo/Components/CameraGuide.h
+++ b/src/app/grapkimbo/Components/CameraGuide.h
@@ -1,6 +1,8 @@
 #pragma once
 
 
+#include "../commons.h"
+
 #include <aunteater/Component.h>
 
 #include <math/Interpolation/Interpolation.h>
@@ -10,6 +12,7 @@
 
 
 namespace ad {
+namespace grapito {
 
 
 struct CameraGuide : public aunteater::Component<CameraGuide>
@@ -22,8 +25,9 @@ struct CameraGuide : public aunteater::Component<CameraGuide>
         Keep,
     };
 
-    CameraGuide(float aInfluence) :
-        influence{aInfluence}
+    CameraGuide(float aInfluence, Vec2 aOffset = {0.f, 0.f}) :
+        influence{aInfluence},
+        offset{aOffset}
     {}
 
     CameraGuide(Interpolation_type aInterpolation, OnCompletion aCompletionBehaviour = OnCompletion::Keep) :
@@ -34,9 +38,11 @@ struct CameraGuide : public aunteater::Component<CameraGuide>
 
 
     float influence;
+    Vec2 offset{0.f, 0.f}; // to offset the guide position relative to the entity position
     std::optional<Interpolation_type> influenceInterpolation;
     OnCompletion completionBehaviour{OnCompletion::Keep};
 };
 
 
+} // namespace grapito
 } // namespace ad

--- a/src/app/grapkimbo/Components/CameraLimits.h
+++ b/src/app/grapkimbo/Components/CameraLimits.h
@@ -1,0 +1,25 @@
+#pragma once
+
+
+#include <aunteater/Component.h>
+
+
+namespace ad {
+namespace grapito {
+
+
+/// \brief Control the limits of what the camera must try to show, relative to the entity position.
+struct CameraLimits : public aunteater::Component<CameraLimits>
+{
+    CameraLimits(float aAbove, float aBelow) :
+        above{aAbove},
+        below{aBelow}
+    {}
+
+    float above{0.f};
+    float below{0.f};
+};
+
+
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Components/Debug/DirectControlTag.h
+++ b/src/app/grapkimbo/Components/Debug/DirectControlTag.h
@@ -1,0 +1,19 @@
+#pragma once
+
+
+#include <aunteater/Component.h>
+
+
+namespace ad {
+namespace grapito {
+namespace debug {
+
+struct DirectControlTag : public aunteater::Component<DirectControlTag>
+{
+    DirectControlTag() = default;
+};
+
+
+} // namespace debug
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Components/ScreenPosition.h
+++ b/src/app/grapkimbo/Components/ScreenPosition.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../commons.h"
+
+#include <aunteater/Component.h>
+
+
+namespace ad {
+namespace grapito {
+
+
+struct ScreenPosition : public aunteater::Component<ScreenPosition>
+{
+    ScreenPosition(Position2 aPosition) :
+        position{aPosition}
+    {}
+
+    Position2 position;
+};
+
+
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Components/Text.h
+++ b/src/app/grapkimbo/Components/Text.h
@@ -1,0 +1,22 @@
+#pragma once
+
+
+#include <aunteater/Component.h>
+
+
+namespace ad {
+namespace grapito {
+
+
+struct Text : public aunteater::Component<Text>
+{
+    Text(std::string aMessage) :
+        message{std::move(aMessage)}
+    {}
+
+    std::string message;
+};
+
+
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -27,7 +27,9 @@ namespace game
 
 namespace player
 {
-    const float gCameraWeight = 1.f;
+    const Vec2 gCameraGuideOffset{0.f, 15.f};
+    const float gCameraGuideWeight = 1.f;
+    const std::array<float, 2> gCameraLimits{7.f, -2.5f};
     const float gIdleSpeedLimit = 1;
     const math::Size<2, float> gSize = math::Size<2, float>{5.6f, 7.5f} / gGigantismDampeningFactor;
     const float gGrappleFriction = 0.5f;

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -22,6 +22,7 @@ namespace debug
 namespace game
 {
     const math::Size<2, int> gAppResolution{1600, 900};
+    const float gCompetitorEliminationDistance = 15.f + (render::gViewedHeight / 2.f);
 } // namespace game
 
 

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -8,6 +8,17 @@ namespace grapito {
 
 constexpr float gGigantismDampeningFactor = 2.f;
 
+
+namespace debug
+{
+    const float gCrossSize = 3.f;
+    const math::sdr::Rgb gDirectControlDrawColor = math::sdr::gBlue;
+    const Size2 gDirectControlDrawSize{gCrossSize, gCrossSize};
+    const float gDirectControlSpeed = 50.f;
+    const float gStepTimeIncrement = 0.016f;
+} // namespace debug
+
+
 namespace game
 {
     const math::Size<2, int> gAppResolution{1600, 900};
@@ -16,6 +27,7 @@ namespace game
 
 namespace player
 {
+    const float gCameraWeight = 1.f;
     const float gIdleSpeedLimit = 1;
     const math::Size<2, float> gSize = math::Size<2, float>{5.6f, 7.5f} / gGigantismDampeningFactor;
     const float gGrappleFriction = 0.5f;

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -6,6 +6,7 @@
 namespace ad {
 namespace grapito {
 
+constexpr float gGigantismDampeningFactor = 2.f;
 
 namespace game
 {
@@ -16,13 +17,14 @@ namespace game
 namespace player
 {
     const float gIdleSpeedLimit = 1;
-    const math::Size<2, float> gSize{5.6f, 7.5f};
+    const math::Size<2, float> gSize = math::Size<2, float>{5.6f, 7.5f} / gGigantismDampeningFactor;
+    const float gGrappleFriction = 0.5f;
 } // namespace player
 
 
 namespace render
 {
-    constexpr int horizontalSpriteScreenResolution = 600;
+    constexpr int horizontalSpriteScreenResolution = 600 * gGigantismDampeningFactor;
     const GLfloat gSpritePixelWorldSize = gViewedHeight / horizontalSpriteScreenResolution;
     const GLfloat gSpriteOpacity = 1.f;
 } // namespace render

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -9,6 +9,11 @@ namespace grapito {
 constexpr float gGigantismDampeningFactor = 2.f;
 
 
+namespace camera
+{
+    const float gCompetitorGuideFadeOutDuration = 1.5f;
+} // namespace camera
+
 namespace debug
 {
     const float gCrossSize = 3.f;

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -28,6 +28,8 @@ namespace game
 {
     const math::Size<2, int> gAppResolution{1600, 900};
     const float gCompetitorEliminationDistance = 15.f + (render::gViewedHeight / 2.f);
+    const float gCongratulationPhaseDuration = 3.f;
+    const Position2 gCongratulationScreenPosition{-200.f, -100.f};
 } // namespace game
 
 

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -31,6 +31,14 @@ namespace game
 } // namespace game
 
 
+namespace hud
+{
+    extern const float gViewedHeight = menu::gViewedHeight;
+    extern const char * const gFont = menu::gFont;
+    extern const GLfloat gTextHeight = menu::gTextHeight * 2;
+}
+
+
 namespace player
 {
     const Vec2 gCameraGuideOffset{0.f, 15.f};

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -53,7 +53,8 @@ namespace game
     constexpr math::hdr::Rgb gClearColor{0.1, 0.2, 0.3};
     // If a competitor fall below this vertical limit, it is eliminated.
     extern const float gCompetitorEliminationDistance;
-
+    extern const float gCongratulationPhaseDuration;
+    extern const Position2 gCongratulationScreenPosition;
 } // namespace game
 
 

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -80,7 +80,7 @@ namespace player
     extern const math::Size<2, float> gSize;
     constexpr float gInitialRopeLength = 3.f;
     constexpr math::Radian<float> gInitialAngle{math::pi<float>/3.f};
-    //TODO(franz) replace with constexpr
+    //TODO(franz) move to impl file
     inline float gAcceleration = 70.f;
     inline float gGroundSpeed = 20.f;
     inline int gGroundNumberOfAccelFrame = 4;
@@ -92,7 +92,8 @@ namespace player
     inline float gJumpImpulse = 24.f; // m/s
     inline float gWallFriction = 4.f; // m/s
     inline float gDoubleJumpFactor = 1.3f; // m/s
-    inline float gGrappleBaseImpulse = 40.f;
+    inline float gGrappleBaseImpulse = 70.f;
+    extern const float gGrappleFriction;
     inline float gRopeDistanceJointFactor = 1.1f;
     //static constexpr double gAirControlAcceleration = 12.; // m/s
     //constexpr double gAcceleration = 10.;

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -36,7 +36,11 @@ namespace controller
 
 namespace debug
 {
-    constexpr float gStepTimeIncrement = 0.016f;
+    extern const float gCrossSize;
+    extern const math::sdr::Rgb gDirectControlDrawColor;
+    extern const Size2 gDirectControlDrawSize;
+    extern const float gDirectControlSpeed;
+    extern const float gStepTimeIncrement;
 };
 
 
@@ -76,6 +80,7 @@ namespace physic
 
 namespace player
 {
+    extern const float gCameraWeight;
     constexpr float gMass = 80.f;
     extern const math::Size<2, float> gSize;
     constexpr float gInitialRopeLength = 3.f;

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -57,6 +57,14 @@ namespace game
 } // namespace game
 
 
+namespace hud
+{
+    extern const float gViewedHeight;
+    extern const char * const gFont;
+    extern const GLfloat gTextHeight;
+}
+
+
 namespace menu
 {
     constexpr int gBlurringPasses = 6;

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -80,7 +80,9 @@ namespace physic
 
 namespace player
 {
-    extern const float gCameraWeight;
+    extern const Vec2 gCameraGuideOffset;
+    extern const float gCameraGuideWeight;
+    extern const std::array<float, 2> gCameraLimits;
     constexpr float gMass = 80.f;
     extern const math::Size<2, float> gSize;
     constexpr float gInitialRopeLength = 3.f;

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -25,7 +25,7 @@ namespace camera
     constexpr float gAnchorGuideFadeOut = 0.8f;
 
     // When a competitor is eliminated, the duration for its camera guide fade out.
-    constexpr float gCompetitorGuideFadeOut = 2.f;
+    extern const float gCompetitorGuideFadeOutDuration;
 }
 
 

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -23,6 +23,9 @@ namespace camera
 {
     constexpr float gAnchorGuideFadeIn = 2.f;
     constexpr float gAnchorGuideFadeOut = 0.8f;
+
+    // When a competitor is eliminated, the duration for its camera guide fade out.
+    constexpr float gCompetitorGuideFadeOut = 2.f;
 }
 
 
@@ -48,6 +51,9 @@ namespace game
 {
     extern const math::Size<2, int> gAppResolution;
     constexpr math::hdr::Rgb gClearColor{0.1, 0.2, 0.3};
+    // If a competitor fall below this vertical limit, it is eliminated.
+    extern const float gCompetitorEliminationDistance;
+
 } // namespace game
 
 

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -46,12 +46,8 @@ aunteater::Entity makePlayer(int aIndex,
 {
     aunteater::Entity player = aunteater::Entity()
         // The component will be populated by AnimationState system.
-        .add<AnimatedSprite>()
-        .add<Controllable>(aController)
-        .add<GrappleControl>(aGrappleMode)
-        .add<PlayerData>(aIndex, aColor)
         .add<AccelAndSpeed>()
-        .add<Position>(Position2{3.f, 3.f}, player::gSize) // The position will be set by pendulum simulation
+        .add<AnimatedSprite>()
         .add<Body>(
             math::Rectangle<float>{{0.f, 0.f}, player::gSize},
             BodyType_Dynamic,
@@ -63,9 +59,15 @@ aunteater::Entity makePlayer(int aIndex,
             1.f,
             std::vector<CollisionType>{CollisionType_Static_Env}
             )
-        //.add<VisualRectangle>(aColor)
-        .add<VisualSprite>() // handled by animation system
+        .add<CameraGuide>(player::gCameraGuideWeight, player::gCameraGuideOffset)
+        .add<CameraLimits>(player::gCameraLimits[0], player::gCameraLimits[1])
+        .add<Controllable>(aController)
+        .add<GrappleControl>(aGrappleMode)
         .add<Mass>(player::gMass)
+        .add<PlayerData>(aIndex, aColor)
+        .add<Position>(Position2{3.f, 3.f}, player::gSize) // The position will be set by pendulum simulation
+        .add<VisualRectangle>(aColor)
+        .add<VisualSprite>() // handled by animation system
     ;
 
     //aPendular.connected->add<CameraGuide>(math::makeInterpolation<math::ease::SmoothStep>(0., 1., 0.3));
@@ -86,8 +88,8 @@ void kill(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityMana
         CameraGuide smoothOut = aPlayer->get<CameraGuide>();
         smoothOut.influenceInterpolation = 
             math::makeInterpolation<math::None, math::ease::SmoothStep>
-                                   (player::gCameraGuideWeight, 0.f, camera::gCompetitorGuideFadeOut);
-        smoothOut.completionBehaviour = CameraGuide::OnCompletion::Remove;
+                                   (smoothOut.influence, 0.f, camera::gCompetitorGuideFadeOutDuration);
+        smoothOut.completionBehaviour = CameraGuide::OnCompletion::RemoveEntity;
 
         aEntityManager.addEntity(aunteater::Entity{}
             .add<CameraGuide>(smoothOut)

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -12,6 +12,8 @@
 #include "Components/PlayerData.h"
 #include "Components/Position.h"
 #include "Components/RopeCreator.h"
+#include "Components/ScreenPosition.h"
+#include "Components/Text.h"
 #include "Components/VisualOutline.h"
 #include "Components/VisualPolygon.h"
 #include "Components/VisualRectangle.h"
@@ -38,6 +40,15 @@ aunteater::Entity makeDirectControllable(Controller aController, Position2 aInit
         .add<Position>(aInitialPosition, Size2{0.f, 0.f})
         ;
 }
+
+
+aunteater::Entity makeHudText(std::string aMessage, Position2 aScreenPosition)
+{
+    return aunteater::Entity{}
+        .add<ScreenPosition>(aScreenPosition)
+        .add<Text>(std::move(aMessage));
+}
+
 
 aunteater::Entity makePlayer(int aIndex,
                              Controller aController,

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -76,25 +76,11 @@ aunteater::Entity makePlayer(int aIndex,
 }
 
 
-void kill(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager)
+void kill(aunteater::weak_entity aPlayer)
 {
     if (aPlayer->get<PlayerData>().grapple != nullptr)
     {
         detachPlayerFromGrapple(aPlayer);
-    }
-
-    // Killing the player will remove its camera guide, make a smooth transition
-    {
-        CameraGuide smoothOut = aPlayer->get<CameraGuide>();
-        smoothOut.influenceInterpolation = 
-            math::makeInterpolation<math::None, math::ease::SmoothStep>
-                                   (smoothOut.influence, 0.f, camera::gCompetitorGuideFadeOutDuration);
-        smoothOut.completionBehaviour = CameraGuide::OnCompletion::RemoveEntity;
-
-        aEntityManager.addEntity(aunteater::Entity{}
-            .add<CameraGuide>(smoothOut)
-            .add<Position>(aPlayer->get<Position>())
-        );
     }
 
     aPlayer->markToRemove();

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -2,6 +2,7 @@
 
 #include "Components/AnimatedSprite.h"
 #include "Components/CameraGuide.h"
+#include "Components/CameraLimits.h"
 #include "Components/CameraTag.h"
 #include "Components/Controllable.h"
 #include "Components/DelayDeletion.h"
@@ -32,6 +33,7 @@ namespace grapito
 aunteater::Entity makeDirectControllable(Controller aController, Position2 aInitialPosition)
 {
     return aunteater::Entity{}
+        .add<CameraLimits>(player::gCameraLimits[0], player::gCameraLimits[1])
         .add<Controllable>(aController)
         .add<debug::DirectControlTag>()
         .add<Position>(aInitialPosition, Size2{0.f, 0.f})

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -16,6 +16,8 @@
 #include "Components/VisualRectangle.h"
 #include "Components/VisualSprite.h"
 
+#include "Components/Debug/DirectControlTag.h"
+
 #include "Utils/PhysicsStructs.h"
 #include "aunteater/EntityManager.h"
 #include "commons.h"
@@ -26,6 +28,15 @@
 namespace ad {
 namespace grapito
 {
+
+aunteater::Entity makeDirectControllable(Controller aController, Position2 aInitialPosition)
+{
+    return aunteater::Entity{}
+        .add<Controllable>(aController)
+        .add<debug::DirectControlTag>()
+        .add<Position>(aInitialPosition, Size2{0.f, 0.f})
+        ;
+}
 
 aunteater::Entity makePlayer(int aIndex,
                              Controller aController,

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -144,6 +144,7 @@ void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEn
                 grapplePos,
                 math::Size<2, float>{1.f, 1.f}
                 )
+            // TODO (Franz): named "configuration" instead of magic numbers.
             .add<Body>(
                 rope::grappleVertices,
                 BodyType_Dynamic,
@@ -151,7 +152,7 @@ void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEn
                 CollisionType_Moving_Env,
                 4.f,
                 0.f,
-                1.f,
+                player::gGrappleFriction,
                 0.3f,
                 std::vector<CollisionType>{CollisionType_Static_Env}
                 )

--- a/src/app/grapkimbo/Entities.h
+++ b/src/app/grapkimbo/Entities.h
@@ -22,12 +22,16 @@ namespace grapito
 {
 
 
+aunteater::Entity makeCamera(Position2 pos = {0.f, 0.f});
+
+aunteater::Entity makeDirectControllable(Controller aController,
+                                         Position2 aInitialPosition = {0.f, 0.f});
+                             
+
 aunteater::Entity makePlayer(int aIndex,
                              Controller aController,
                              math::sdr::Rgb aColor,
                              GrappleMode aGrappleMode = GrappleMode::Closest);
-
-aunteater::Entity makeCamera(Position2 pos = {0.f, 0.f});
 
 
 aunteater::Entity makeAnchor(Position2 aPosition, math::Size<2, float> aSize);

--- a/src/app/grapkimbo/Entities.h
+++ b/src/app/grapkimbo/Entities.h
@@ -33,6 +33,7 @@ aunteater::Entity makePlayer(int aIndex,
                              math::sdr::Rgb aColor,
                              GrappleMode aGrappleMode = GrappleMode::Closest);
 
+void kill(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager);
 
 aunteater::Entity makeAnchor(Position2 aPosition, math::Size<2, float> aSize);
 aunteater::Entity makeAnchor(Position2 aPosition, std::vector<Position2> aVertices);
@@ -40,7 +41,7 @@ aunteater::Entity makeAnchor(Position2 aPosition, std::vector<Position2> aVertic
 
 aunteater::Entity createRopeSegment(Position2 origin, Position2 endRR);
 
-void throwGrapple(aunteater::weak_entity aEntity, aunteater::EntityManager & aEntityManager);
+void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager);
 
 void attachPlayerToGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager);
 

--- a/src/app/grapkimbo/Entities.h
+++ b/src/app/grapkimbo/Entities.h
@@ -28,6 +28,8 @@ aunteater::Entity makeDirectControllable(Controller aController,
                                          Position2 aInitialPosition = {0.f, 0.f});
                              
 
+aunteater::Entity makeHudText(std::string aMessage, Position2 aScreenPosition);
+
 aunteater::Entity makePlayer(int aIndex,
                              Controller aController,
                              math::sdr::Rgb aColor,

--- a/src/app/grapkimbo/Entities.h
+++ b/src/app/grapkimbo/Entities.h
@@ -33,7 +33,7 @@ aunteater::Entity makePlayer(int aIndex,
                              math::sdr::Rgb aColor,
                              GrappleMode aGrappleMode = GrappleMode::Closest);
 
-void kill(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager);
+void kill(aunteater::weak_entity aPlayer);
 
 aunteater::Entity makeAnchor(Position2 aPosition, math::Size<2, float> aSize);
 aunteater::Entity makeAnchor(Position2 aPosition, std::vector<Position2> aVertices);

--- a/src/app/grapkimbo/Input.cpp
+++ b/src/app/grapkimbo/Input.cpp
@@ -34,6 +34,7 @@ const GamepadInputConfig gGamepadConfig = {
     GamepadInputMapping{Jump,       GLFW_GAMEPAD_BUTTON_A, Button},
     GamepadInputMapping{Grapple,    GLFW_GAMEPAD_BUTTON_B, Button},
     GamepadInputMapping{ChangeMode, GLFW_GAMEPAD_BUTTON_Y, Button},
+    GamepadInputMapping{R3,         GLFW_GAMEPAD_BUTTON_RIGHT_THUMB, Button},
     GamepadInputMapping{Start,      GLFW_GAMEPAD_BUTTON_START, Button},
     GamepadInputMapping{LeftHorizontalAxis,  GLFW_GAMEPAD_AXIS_LEFT_X, Axis},
     GamepadInputMapping{LeftVerticalAxis,    GLFW_GAMEPAD_AXIS_LEFT_Y, AxisInverted},

--- a/src/app/grapkimbo/Input.cpp
+++ b/src/app/grapkimbo/Input.cpp
@@ -19,6 +19,7 @@ const KeyboardInputConfig gKeyboardConfig = {
     KeyboardInputMapping{Jump,      GLFW_KEY_SPACE},
     KeyboardInputMapping{Grapple,   GLFW_KEY_X},
     KeyboardInputMapping{Start,     GLFW_KEY_ENTER},
+    KeyboardInputMapping{Back,      GLFW_KEY_BACKSPACE},
 
     // Debugging
     KeyboardInputMapping{Pause, GLFW_KEY_P},
@@ -36,6 +37,7 @@ const GamepadInputConfig gGamepadConfig = {
     GamepadInputMapping{ChangeMode, GLFW_GAMEPAD_BUTTON_Y, Button},
     GamepadInputMapping{R3,         GLFW_GAMEPAD_BUTTON_RIGHT_THUMB, Button},
     GamepadInputMapping{Start,      GLFW_GAMEPAD_BUTTON_START, Button},
+    GamepadInputMapping{Back,       GLFW_GAMEPAD_BUTTON_BACK, Button},
     GamepadInputMapping{LeftHorizontalAxis,  GLFW_GAMEPAD_AXIS_LEFT_X, Axis},
     GamepadInputMapping{LeftVerticalAxis,    GLFW_GAMEPAD_AXIS_LEFT_Y, AxisInverted},
     GamepadInputMapping{RightHorizontalAxis, GLFW_GAMEPAD_AXIS_RIGHT_X, Axis},

--- a/src/app/grapkimbo/Input.h
+++ b/src/app/grapkimbo/Input.h
@@ -21,6 +21,7 @@ enum Command {
     Jump,
     Grapple,
     ChangeMode, // intended to change the grappling mode (see GrappleControl component)
+    R3,
     Start,
     Pause,
     Step,

--- a/src/app/grapkimbo/Input.h
+++ b/src/app/grapkimbo/Input.h
@@ -23,6 +23,7 @@ enum Command {
     ChangeMode, // intended to change the grappling mode (see GrappleControl component)
     R3,
     Start,
+    Back,
     Pause,
     Step,
     LeftHorizontalAxis,

--- a/src/app/grapkimbo/Scenery/GameScene.cpp
+++ b/src/app/grapkimbo/Scenery/GameScene.cpp
@@ -19,7 +19,7 @@ GameScene::GameScene(std::shared_ptr<Context> aContext,
 
 
 UpdateStatus GameScene::update(
-    GrapitoTimer & aTimer,
+    const GrapitoTimer & aTimer,
     const GameInputState & aInputs,
     StateMachine & aStateMachine)
 {
@@ -43,14 +43,17 @@ UpdateStatus GameScene::update(
 
     if (!mSystemManager.isPaused() || debugStep.positiveEdge())
     {
+        // Make a copy, so the timer values can be modified for stepping.
+        GrapitoTimer timerCopy = aTimer;
         if (mSystemManager.isPaused())
         {
+            // TODO
             // The delta will be correct, but the resulting simulation time might not be
-            // if current delta() (computer from real time in main) is not zero.
-            aTimer.mark(aTimer.simulationTime() + debug::gStepTimeIncrement);
+            // if current delta() (computed from real time in main) is not zero.
+            timerCopy.mark(timerCopy.simulationTime() + debug::gStepTimeIncrement);
         }
 
-        mSystemManager.step(aTimer, aInputs, mUpdater);
+        mSystemManager.step(timerCopy, aInputs, mUpdater);
         log(mUpdater);
         return UpdateStatus::SwapBuffers;
     }

--- a/src/app/grapkimbo/Scenery/GameScene.h
+++ b/src/app/grapkimbo/Scenery/GameScene.h
@@ -23,7 +23,7 @@ public:
 
     /// \brief Complete update step, including rendering.
     UpdateStatus update(
-        GrapitoTimer & aTimer,
+        const GrapitoTimer & aTimer,
         const GameInputState & aInputs,
         StateMachine & aStateMachine) override;
 

--- a/src/app/grapkimbo/Scenery/MenuScene.cpp
+++ b/src/app/grapkimbo/Scenery/MenuScene.cpp
@@ -44,7 +44,7 @@ MenuScene::MenuScene(Menu aMenu,
 
 
 UpdateStatus MenuScene::update(
-        GrapitoTimer & aTimer,
+        const GrapitoTimer & aTimer,
         const GameInputState & aInputs,
         StateMachine & aStateMachine)
 {
@@ -87,7 +87,7 @@ void MenuScene::beforeExit()
 }
 
 
-std::pair<TransitionProgress, UpdateStatus> MenuScene::scrollMenu(GrapitoTimer & aTimer)
+std::pair<TransitionProgress, UpdateStatus> MenuScene::scrollMenu(const GrapitoTimer & aTimer)
 {
     Rectangle viewed = graphics::getViewRectangle(mAppInterface->getFramebufferSize(), menu::gViewedHeight);
     viewed.origin().x() = mMenuXPosition.advance(aTimer.delta());

--- a/src/app/grapkimbo/Scenery/MenuScene.h
+++ b/src/app/grapkimbo/Scenery/MenuScene.h
@@ -60,18 +60,18 @@ public:
               std::shared_ptr<GameScene> aGameScene = nullptr);
 
     UpdateStatus update(
-        GrapitoTimer & aTimer,
+        const GrapitoTimer & aTimer,
         const GameInputState & aInputs,
         StateMachine & aStateMachine) override;
 
     std::pair<TransitionProgress, UpdateStatus> enter(
-        GrapitoTimer & aTimer,
+        const GrapitoTimer & aTimer,
         const GameInputState &,
         const StateMachine &) override
     { return scrollMenu(aTimer); }
 
     std::pair<TransitionProgress, UpdateStatus> exit(
-        GrapitoTimer & aTimer,
+        const GrapitoTimer & aTimer,
         const GameInputState &,
         const StateMachine &) override
     { return scrollMenu(aTimer); }
@@ -80,7 +80,7 @@ public:
     void beforeExit() override;
 
 private:
-    std::pair<TransitionProgress, UpdateStatus> scrollMenu(GrapitoTimer & aTimer);
+    std::pair<TransitionProgress, UpdateStatus> scrollMenu(const GrapitoTimer & aTimer);
 
     /// \brief Generate menu geometry and fonts, and update all vertex buffers of renderers.
     void updateMenuBuffers();

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -154,7 +154,9 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
 
     mEntityManager.addEntity(
         makePlayer(0, controller, math::sdr::gCyan)
-            .add<CameraGuide>(player::gCameraWeight));
+            .add<CameraGuide>(player::gCameraGuideWeight, player::gCameraGuideOffset)
+            .add<CameraLimits>(player::gCameraLimits[0], player::gCameraLimits[1])
+    );
 
     // Debug direct control (for camera influence)
     mEntityManager.addEntity(

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -68,35 +68,81 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
 
     // Camera
     aunteater::weak_entity camera = mEntityManager.addEntity(makeCamera());
-    //floors
-    aunteater::weak_entity polygon = mEntityManager.addEntity(
-        makeAnchor(Position2{ 5.f, 7.f }, std::vector<Position2>{
-        Position2{ 0.f, 0.f }, Position2{ 1.5f, 0.f }, Position2{ 2.5f, 0.5f },
-            Position2{ 2.75f, 2.f }, Position2{ 2.f, 3.f }, Position2{ 0.5f, 2.5f },
-            Position2{ 0.f, 1.f }
-    }));
-    aunteater::weak_entity floor = mEntityManager.addEntity(
-        makeAnchor(Position2{ -20.f, -4.f }, math::Size<2, float>{40.f, 2.f}));
-    aunteater::weak_entity floor2 = mEntityManager.addEntity(
-        makeAnchor(Position2{20.f, -2.f}, math::Size<2, float>{40.f, 2.f} ));    
-    mEntityManager.addEntity(
-            makeAnchor(Position2{ 15.f, 15.f }, math::Size<2, float>{40.f, 2.f}));
-    mEntityManager.addEntity(
-        makeAnchor(Position2{ 5.f, 25.f }, std::vector<Position2>{
-            Position2{ 0.f, 0.f }, Position2{ 11.5f, 0.f }, Position2{ 12.5f, 0.5f },
-            Position2{ 12.75f, 2.f }, Position2{ 12.f, 3.f }, Position2{ 0.5f, 3.f },
-            Position2{ 0.f, 1.f }
-    }));
-    mEntityManager.addEntity(
-        makeAnchor(Position2{ -10.f, 45.f }, std::vector<Position2>{
-        Position2{ 0.f, 0.f }, Position2{ 7.f, -5.f }, Position2{ 14.f, 0.f },
-    }));
-    //wall
-    mEntityManager.addEntity(
-        makeAnchor(Position2{-20.f, -2.f}, math::Size<2, float>{2.f, 100.f} ));
-    //wall2
-    mEntityManager.addEntity(
-        makeAnchor(Position2{ 60.f, -2.f }, math::Size<2, float>{2.f, 100.f}));
+
+    constexpr float gLevelHalfWidth = 50.f;
+
+    //
+    // Level
+    //
+    {
+        //floors
+        aunteater::weak_entity floor = mEntityManager.addEntity(
+            makeAnchor(Position2{ -gLevelHalfWidth, -4.f }, math::Size<2, float>{gLevelHalfWidth, 2.f}));
+        aunteater::weak_entity floor2 = mEntityManager.addEntity(
+            makeAnchor(Position2{0.f, -2.f}, math::Size<2, float>{gLevelHalfWidth, 2.f} ));    
+
+        // First anchor
+        aunteater::weak_entity polygon = mEntityManager.addEntity(
+            makeAnchor(Position2{ -15.f, 10.f }, std::vector<Position2>{
+            Position2{ 0.f, 0.f }, Position2{ 1.5f, 0.f }, Position2{ 2.5f, 0.5f },
+                Position2{ 2.75f, 2.f }, Position2{ 2.f, 3.f }, Position2{ 0.5f, 2.5f },
+                Position2{ 0.f, 1.f }
+        }));
+
+
+        // 1st square
+        mEntityManager.addEntity(
+                makeAnchor(Position2{ 10.f, 28.f }, math::Size<2, float>{3.f, 3.f}));
+
+        // 1st level platform
+        mEntityManager.addEntity(
+                makeAnchor(Position2{ 23.f, 17.f }, math::Size<2, float>{30.f, 2.f}));
+
+        mEntityManager.addEntity(
+            makeAnchor(Position2{ 35.f, 30.f }, std::vector<Position2>{
+                Position2{ 0.f, 0.f }, Position2{ 11.5f, 0.f }, Position2{ 12.5f, 0.5f },
+                Position2{ 12.75f, 2.f }, Position2{ 12.f, 3.f }, Position2{ 0.5f, 3.f },
+                Position2{ 0.f, 1.f }
+        }));
+
+        // Triangle
+        mEntityManager.addEntity(
+            makeAnchor(Position2{ -30.f, 40.f }, std::vector<Position2>{
+            Position2{ 0.f, 0.f }, Position2{ 7.f, -5.f }, Position2{ 14.f, 0.f },
+        }));
+
+        // 2nd square
+        mEntityManager.addEntity(
+                makeAnchor(Position2{ 0.f, 50.f }, math::Size<2, float>{3.f, 3.f}));
+
+        // 3nd square
+        mEntityManager.addEntity(
+                makeAnchor(Position2{ 22.f, 65.f }, math::Size<2, float>{4.f, 4.f}));
+
+        // 4th square
+        mEntityManager.addEntity(
+                makeAnchor(Position2{ -10.f, 80.f }, math::Size<2, float>{3.f, 3.f}));
+
+        // 5th square
+        mEntityManager.addEntity(
+                makeAnchor(Position2{ -15.f, 100.f }, math::Size<2, float>{3.f, 3.f}));
+
+        // 6th square
+        mEntityManager.addEntity(
+                makeAnchor(Position2{ 25.f, 85.f }, math::Size<2, float>{6.f, 6.f}));
+
+        // 7th square
+        mEntityManager.addEntity(
+                makeAnchor(Position2{ 0.f, 115.f }, math::Size<2, float>{3.f, 3.f}));
+
+        //wall
+        mEntityManager.addEntity(
+            makeAnchor(Position2{-gLevelHalfWidth, -2.f}, math::Size<2, float>{2.f, 100.f} ));
+        //wall2
+        mEntityManager.addEntity(
+            makeAnchor(Position2{ gLevelHalfWidth, -2.f }, math::Size<2, float>{2.f, 100.f}));
+    }
+
 
     // Player 1
     Controller controller = isGamepadPresent(Controller::Gamepad_0) ?

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -34,10 +34,36 @@ namespace ad {
 namespace grapito {
 
 
+std::vector<aunteater::Entity> setupPlayers()
+{
+    std::vector<aunteater::Entity> players;
+
+    // Player 1
+    {
+        //Controller controller = isGamepadPresent(Controller::Gamepad_0) ?
+        //                        Controller::Gamepad_0 : Controller::KeyboardMouse;
+        Controller controller = Controller::Gamepad_0;
+        players.push_back(makePlayer(0, controller, math::sdr::gCyan));
+    }
+
+    // Player 2
+    {
+        Controller controller = Controller::Gamepad_1;
+        if (isGamepadPresent(controller))
+        {
+            players.push_back(makePlayer(1, controller, math::sdr::gMagenta));
+        }
+    }
+
+    return players;
+}
+
+
 RopeGame::RopeGame(std::shared_ptr<Context> aContext,
                    std::shared_ptr<graphics::AppInterface> aAppInterface) :
     GameScene{std::move(aContext), std::move(aAppInterface)}
 {
+    std::vector<aunteater::Entity> players = setupPlayers();
 
     mSystemManager.add<debug::DirectControl>();
 
@@ -57,7 +83,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
     mSystemManager.add<DelayDeleter>();
 
     // Done after CameraGuidedControl, to avoid having two camera guides on the frame a player is killed.
-    mSystemManager.add<GameRule>();
+    mSystemManager.add<GameRule>(players);
 
     mRenderSystem = mSystemManager.add<Render>(mAppInterface); 
 
@@ -151,31 +177,23 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
             makeAnchor(Position2{ gLevelHalfWidth, -2.f }, math::Size<2, float>{2.f, 100.f}));
     }
 
-
-    // Player 1
-    //Controller controller = isGamepadPresent(Controller::Gamepad_0) ?
-    //                        Controller::Gamepad_0 : Controller::KeyboardMouse;
-    Controller controller = Controller::Gamepad_0;
-
-    mEntityManager.addEntity(
-        makePlayer(0, controller, math::sdr::gCyan)
-    );
-
-    // Debug direct control (for camera influence)
-    mEntityManager.addEntity(
-        makeDirectControllable(controller)
-    );
-
-    // Player 2
+    //
+    // Players
+    //
     {
-        //Controller controller = Controller::Gamepad_1;
-        Controller controller = Controller::KeyboardMouse;
-        if (isGamepadPresent(controller))
+        for (const auto & player : players)
         {
-            mEntityManager.addEntity(
-                makePlayer(1, controller, math::sdr::gMagenta));
+            mEntityManager.addEntity(player);
         }
+
+        // Debug direct control (for camera influence)
+        mEntityManager.addEntity(
+            makeDirectControllable(players[0].get<Controllable>().controller)
+        );
+
     }
+
+
 }
 
 

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -1,9 +1,11 @@
 #include "RopeGame.h"
 
 #include "../Entities.h"
+
 #include "Systems/DelayDeleter.h"
 #include "Systems/GrappleCleanup.h"
 #include "Systems/GrappleJointCreator.h"
+#include "Systems/Debug/DirectControl.h"
 
 #include <Components/AccelAndSpeed.h>
 #include <Components/Body.h>
@@ -35,6 +37,8 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
                    std::shared_ptr<graphics::AppInterface> aAppInterface) :
     GameScene{std::move(aContext), std::move(aAppInterface)}
 {
+
+    mSystemManager.add<debug::DirectControl>();
 
     mSystemManager.add<Control>();
     mSystemManager.add<Gravity>();
@@ -150,7 +154,12 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
 
     mEntityManager.addEntity(
         makePlayer(0, controller, math::sdr::gCyan)
-            .add<CameraGuide>(1.0f));
+            .add<CameraGuide>(player::gCameraWeight));
+
+    // Debug direct control (for camera influence)
+    mEntityManager.addEntity(
+        makeDirectControllable(controller)
+    );
 
     // Player 2
     if (isGamepadPresent(Controller::Gamepad_1))

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -21,6 +21,7 @@
 #include <Systems/Control.h>
 #include <Systems/GameRule.h>
 #include <Systems/Gravity.h>
+#include <Systems/Hud.h>
 #include <Systems/LevelGeneration.h>
 #include <Systems/Render.h>
 #include <Systems/Physics.h>
@@ -86,6 +87,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
     mSystemManager.add<GameRule>(players);
 
     mRenderSystem = mSystemManager.add<Render>(mAppInterface); 
+    mSystemManager.add<Hud>(mContext->pathFor(hud::gFont), mAppInterface); 
 
     { // Load sprite animations
         // Note: It is not obvious whether it is better to maintain a permanent instance of the sprite sheet
@@ -192,8 +194,6 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
         );
 
     }
-
-
 }
 
 

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -153,13 +153,12 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
 
 
     // Player 1
-    Controller controller = isGamepadPresent(Controller::Gamepad_0) ?
-                            Controller::Gamepad_0 : Controller::KeyboardMouse;
+    //Controller controller = isGamepadPresent(Controller::Gamepad_0) ?
+    //                        Controller::Gamepad_0 : Controller::KeyboardMouse;
+    Controller controller = Controller::Gamepad_0;
 
     mEntityManager.addEntity(
         makePlayer(0, controller, math::sdr::gCyan)
-            .add<CameraGuide>(player::gCameraGuideWeight, player::gCameraGuideOffset)
-            .add<CameraLimits>(player::gCameraLimits[0], player::gCameraLimits[1])
     );
 
     // Debug direct control (for camera influence)
@@ -168,10 +167,14 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
     );
 
     // Player 2
-    if (isGamepadPresent(Controller::Gamepad_1))
     {
-        mEntityManager.addEntity(
-            makePlayer(1, Controller::Gamepad_1, math::sdr::gMagenta));
+        //Controller controller = Controller::Gamepad_1;
+        Controller controller = Controller::KeyboardMouse;
+        if (isGamepadPresent(controller))
+        {
+            mEntityManager.addEntity(
+                makePlayer(1, controller, math::sdr::gMagenta));
+        }
     }
 }
 

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -19,6 +19,7 @@
 #include <Systems/AccelSolver.h>
 #include <Systems/CameraGuidedControl.h>
 #include <Systems/Control.h>
+#include <Systems/GameRule.h>
 #include <Systems/Gravity.h>
 #include <Systems/LevelGeneration.h>
 #include <Systems/Render.h>
@@ -54,6 +55,9 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
     mSystemManager.add<CameraGuidedControl>();
     mSystemManager.add<GrappleCleanup>();
     mSystemManager.add<DelayDeleter>();
+
+    // Done after CameraGuidedControl, to avoid having two camera guides on the frame a player is killed.
+    mSystemManager.add<GameRule>();
 
     mRenderSystem = mSystemManager.add<Render>(mAppInterface); 
 

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -41,9 +41,8 @@ std::vector<aunteater::Entity> setupPlayers()
 
     // Player 1
     {
-        //Controller controller = isGamepadPresent(Controller::Gamepad_0) ?
-        //                        Controller::Gamepad_0 : Controller::KeyboardMouse;
-        Controller controller = Controller::Gamepad_0;
+        Controller controller = isGamepadPresent(Controller::Gamepad_0) ?
+                                Controller::Gamepad_0 : Controller::KeyboardMouse;
         players.push_back(makePlayer(0, controller, math::sdr::gCyan));
     }
 

--- a/src/app/grapkimbo/Scenery/SplashScene.cpp
+++ b/src/app/grapkimbo/Scenery/SplashScene.cpp
@@ -32,7 +32,7 @@ SplashScene::SplashScene(math::Size<2, int> aResolution) :
 
 
 UpdateStatus SplashScene::update(
-    GrapitoTimer & aTimer,
+    const GrapitoTimer & aTimer,
     const GameInputState & aInputs,
     StateMachine & aStateMachine)
 {

--- a/src/app/grapkimbo/Scenery/SplashScene.h
+++ b/src/app/grapkimbo/Scenery/SplashScene.h
@@ -31,7 +31,7 @@ public:
     SplashScene(math::Size<2, int> aResolution);
 
     UpdateStatus update(
-        GrapitoTimer & aTimer,
+        const GrapitoTimer & aTimer,
         const GameInputState & aInputs,
         StateMachine & aStateMachine) override;
 

--- a/src/app/grapkimbo/Scenery/StateMachine.h
+++ b/src/app/grapkimbo/Scenery/StateMachine.h
@@ -174,6 +174,7 @@ inline void StateMachine::enterNextState()
 inline UpdateStatus StateMachine::update(const GrapitoTimer & aTimer, const GameInputState & aInputs)
 {
     // If the active state is not the top of the stack anymore, the active state is being exited.
+    // TODO If the same shared_ptr is added on top of itself, the transtion is not taking place!
     if (mActiveState.first.get() != mStates.back().get())
     {
         // Only "Updating" should be able to move to "Exiting".

--- a/src/app/grapkimbo/Scenery/StateMachine.h
+++ b/src/app/grapkimbo/Scenery/StateMachine.h
@@ -60,7 +60,7 @@ public:
     /// \return True if  the frame buffer should be swapped.
     /// \note Leaves the door open to timer manipulation (e.g. debug stepping).
     virtual UpdateStatus update(
-        GrapitoTimer & aTimer,
+        const GrapitoTimer & aTimer,
         const GameInputState & aInputs,
         StateMachine & aStateMachine) = 0;
 
@@ -69,13 +69,13 @@ public:
     // Note: StateMachine argument is made a const reference, to intentionally prevent
     // transition from altering the sequence of states.
     virtual std::pair<TransitionProgress, UpdateStatus> enter(
-        GrapitoTimer &,
+        const GrapitoTimer &,
         const GameInputState &,
         const StateMachine &)
     { return {TransitionProgress::None, UpdateStatus::KeepFrame}; }
 
     virtual std::pair<TransitionProgress, UpdateStatus> exit(
-        GrapitoTimer &,
+        const GrapitoTimer &,
         const GameInputState &,
         const StateMachine &)
     { return {TransitionProgress::None, UpdateStatus::KeepFrame}; }
@@ -93,7 +93,7 @@ public:
 /// It just allows to make a normal transition to the next state.
 class EmptyState : public State
 {
-    UpdateStatus update(GrapitoTimer & , const GameInputState & , StateMachine &) override
+    UpdateStatus update(const GrapitoTimer &, const GameInputState &, StateMachine &) override
     {
         return UpdateStatus::KeepFrame;
     }
@@ -110,7 +110,7 @@ public:
     StateMachine(std::shared_ptr<State> aInitialState);
     StateMachine();
 
-    UpdateStatus update(GrapitoTimer & aTimer, const GameInputState & aInputs);
+    UpdateStatus update(const GrapitoTimer & aTimer, const GameInputState & aInputs);
 
     State & topState();
 
@@ -171,7 +171,7 @@ inline void StateMachine::enterNextState()
 }
 
 
-inline UpdateStatus StateMachine::update(GrapitoTimer & aTimer, const GameInputState & aInputs)
+inline UpdateStatus StateMachine::update(const GrapitoTimer & aTimer, const GameInputState & aInputs)
 {
     // If the active state is not the top of the stack anymore, the active state is being exited.
     if (mActiveState.first.get() != mStates.back().get())

--- a/src/app/grapkimbo/Scenery/StateMachine.h
+++ b/src/app/grapkimbo/Scenery/StateMachine.h
@@ -89,12 +89,24 @@ public:
 };
 
 
+/// \brief A dummy state added as the first in a state machine constructed without an explicit initial state.
+/// It just allows to make a normal transition to the next state.
+class EmptyState : public State
+{
+    UpdateStatus update(GrapitoTimer & , const GameInputState & , StateMachine &) override
+    {
+        return UpdateStatus::KeepFrame;
+    }
+};
+
+
 using State_ptr = std::shared_ptr<State>;
 
 class StateMachine
 {
 public:
-    StateMachine(State_ptr aInitialState);
+    StateMachine(std::shared_ptr<State> aInitialState);
+    StateMachine();
 
     UpdateStatus update(GrapitoTimer & aTimer, const GameInputState & aInputs);
 
@@ -142,6 +154,14 @@ inline StateMachine::StateMachine(std::shared_ptr<State> aInitialState) :
     mActiveState.first->beforeEnter();
 }
 
+
+inline StateMachine::StateMachine() :
+    StateMachine{std::make_shared<EmptyState>()}
+{
+    // Otherwise, the assertion that the active state cannot be "Entering" 
+    // when it is not at the top will not hold true.
+    mActiveState.second = Phase::Updating;
+}
 
 inline void StateMachine::enterNextState()
 {

--- a/src/app/grapkimbo/Scenery/StateMachine.h
+++ b/src/app/grapkimbo/Scenery/StateMachine.h
@@ -102,6 +102,8 @@ class EmptyState : public State
 
 using State_ptr = std::shared_ptr<State>;
 
+// TODO Ad 2012/12/23: This StateMachine class is sometimes used as a generic state machine (e.g. GameRule system)
+// Yet the UpdateStatus return type is somewhat coupled to the top-level flow state machine.
 class StateMachine
 {
 public:

--- a/src/app/grapkimbo/Systems/CameraGuidedControl.cpp
+++ b/src/app/grapkimbo/Systems/CameraGuidedControl.cpp
@@ -48,10 +48,15 @@ void CameraGuidedControl::update(const GrapitoTimer aTimer, const GameInputState
         if (cameraGuide.influenceInterpolation) 
         {
             cameraGuide.influence = cameraGuide.influenceInterpolation->advance(aTimer.delta());
-            if (cameraGuide.completionBehaviour == CameraGuide::OnCompletion::Remove
+            if (cameraGuide.completionBehaviour == CameraGuide::OnCompletion::RemoveComponent
                 && cameraGuide.influenceInterpolation->isCompleted())
             {
                 cameraPoint->markComponentToRemove<CameraGuide>();
+            }
+            else if (cameraGuide.completionBehaviour == CameraGuide::OnCompletion::RemoveEntity
+                     && cameraGuide.influenceInterpolation->isCompleted())
+            {
+                cameraPoint->markToRemove();
             }
         }
         Position2 guidePosition = geometry.position + cameraGuide.offset;

--- a/src/app/grapkimbo/Systems/CameraGuidedControl.cpp
+++ b/src/app/grapkimbo/Systems/CameraGuidedControl.cpp
@@ -16,6 +16,18 @@ CameraGuidedControl::CameraGuidedControl(aunteater::EntityManager & aEntityManag
 {}
 
 
+Influence accumulateCameraGuides(const aunteater::FamilyHelp<CameraPoint> & aCameraPoints)
+{
+    Influence result{};
+    for (auto & [cameraGuide, geometry] : aCameraPoints)
+    {
+        result.accumulatedPosition += weightedGuideContribution(geometry, cameraGuide);
+        result.totalWeight += cameraGuide.influence;
+    }
+    return result;
+}
+
+
 Position2 placeCamera(Position2 aAveragePosition, float aLowerLimit, float aUpperLimit)
 {
     // Important: this expects that the window ratio cannot change.

--- a/src/app/grapkimbo/Systems/CameraGuidedControl.cpp
+++ b/src/app/grapkimbo/Systems/CameraGuidedControl.cpp
@@ -1,5 +1,9 @@
 #include "CameraGuidedControl.h"
 
+#include "../Configuration.h"
+
+#include "../Utils/DrawDebugStuff.h"
+
 
 namespace ad {
 namespace grapito {
@@ -31,9 +35,11 @@ void CameraGuidedControl::update(const GrapitoTimer aTimer, const GameInputState
         totalInfluence += cameraGuide.influence;
     }
 
+    // We know there is only one camera, but this allows to treat the camera an any other entity.
     for(const auto camera : mCameras)
     {
         camera->get<Position>().position = (accumulatedPosition / totalInfluence).as<math::Position>() ;
+        debugDrawer->drawCross({camera->get<Position>().position, debug::gCrossSize, math::sdr::gMagenta});
     }
 }
 

--- a/src/app/grapkimbo/Systems/CameraGuidedControl.h
+++ b/src/app/grapkimbo/Systems/CameraGuidedControl.h
@@ -18,7 +18,7 @@ namespace grapito
 {
 
 using Camera = aunteater::Archetype<CameraTag, Position>;
-using CameraPoints = aunteater::Archetype<CameraGuide, Position>;
+using CameraPoint = aunteater::Archetype<CameraGuide, Position>;
 // the CameraLimits are accessed via a separate family, instead of merged into CameraPoints.
 // this is because for player-eliminiation fade-out guides, limits would be a nuisance.
 using CameraLimiter = aunteater::Archetype<CameraLimits, Position>;
@@ -33,10 +33,21 @@ public:
 
 private:
     const aunteater::FamilyHelp<Camera> mCameras;
-    const aunteater::FamilyHelp<CameraPoints> mCameraPoints;
+    const aunteater::FamilyHelp<CameraPoint> mCameraPoints;
     const aunteater::FamilyHelp<CameraLimiter> mCameraLimiters;
 
 };
+
+
+struct Influence
+{
+    math::Vec<2, float> accumulatedPosition{math::Vec<2, float>::Zero()};
+    float totalWeight;
+};
+
+/// \brief Sum all the camera points in `aCameraPoints` into an Influence instance.
+Influence accumulateCameraGuides(const aunteater::FamilyHelp<CameraPoint> & aCameraPoints);
+
 
 } // namespace grapito
 } // namespace ad

--- a/src/app/grapkimbo/Systems/CameraGuidedControl.h
+++ b/src/app/grapkimbo/Systems/CameraGuidedControl.h
@@ -4,6 +4,7 @@
 #include "../Input.h"
 
 #include "../Components/CameraGuide.h"
+#include "../Components/CameraLimits.h"
 #include "../Components/CameraTag.h"
 #include "../Components/Position.h"
 
@@ -17,7 +18,7 @@ namespace grapito
 {
 
 using Camera = aunteater::Archetype<CameraTag, Position>;
-using CameraPoints = aunteater::Archetype<CameraGuide, Position>;
+using CameraPoints = aunteater::Archetype<CameraGuide, CameraLimits, Position>;
 
 
 class CameraGuidedControl : public aunteater::System<GrapitoTimer, GameInputState>

--- a/src/app/grapkimbo/Systems/CameraGuidedControl.h
+++ b/src/app/grapkimbo/Systems/CameraGuidedControl.h
@@ -18,7 +18,10 @@ namespace grapito
 {
 
 using Camera = aunteater::Archetype<CameraTag, Position>;
-using CameraPoints = aunteater::Archetype<CameraGuide, CameraLimits, Position>;
+using CameraPoints = aunteater::Archetype<CameraGuide, Position>;
+// the CameraLimits are accessed via a separate family, instead of merged into CameraPoints.
+// this is because for player-eliminiation fade-out guides, limits would be a nuisance.
+using CameraLimiter = aunteater::Archetype<CameraLimits, Position>;
 
 
 class CameraGuidedControl : public aunteater::System<GrapitoTimer, GameInputState>
@@ -31,6 +34,7 @@ public:
 private:
     const aunteater::FamilyHelp<Camera> mCameras;
     const aunteater::FamilyHelp<CameraPoints> mCameraPoints;
+    const aunteater::FamilyHelp<CameraLimiter> mCameraLimiters;
 
 };
 

--- a/src/app/grapkimbo/Systems/Control.cpp
+++ b/src/app/grapkimbo/Systems/Control.cpp
@@ -45,7 +45,7 @@ void Control::update(const GrapitoTimer, const GameInputState & aInputState)
             horizontalAxis = direction.x();
         }
 
-        // TODO FP: Soething more robust to determine axis sign.
+        // TODO FP: Something more robust to determine axis sign.
         float horizontalAxisSign = horizontalAxis == 0 ? 1.f : (horizontalAxis / std::abs(horizontalAxis));
 
         float groundSpeedAccelFactor = 1.f / player::gGroundNumberOfAccelFrame;

--- a/src/app/grapkimbo/Systems/Control.h
+++ b/src/app/grapkimbo/Systems/Control.h
@@ -2,13 +2,13 @@
 
 #include "Input.h"
 
-#include <Components/Controllable.h>
-#include <Components/Body.h>
 #include <Components/AccelAndSpeed.h>
+#include <Components/Body.h>
+#include <Components/Controllable.h>
 #include <Components/GrappleControl.h>
+#include <Components/Mass.h>
 #include <Components/PlayerData.h>
 #include <Components/Position.h>
-#include <Components/Mass.h>
 
 #include <aunteater/Archetype.h>
 #include <aunteater/FamilyHelp.h>

--- a/src/app/grapkimbo/Systems/Debug/DirectControl.cpp
+++ b/src/app/grapkimbo/Systems/Debug/DirectControl.cpp
@@ -5,6 +5,7 @@
 #include "../../Utils/DrawDebugStuff.h"
 
 #include "../../Components/CameraGuide.h"
+#include "../../Components/CameraLimits.h"
 
 
 namespace ad {
@@ -26,10 +27,13 @@ void DirectControl::update(const GrapitoTimer aTimer, const GameInputState & aIn
             if (directControllable->has<CameraGuide>())
             {
                 directControllable->markComponentToRemove<CameraGuide>();
+                directControllable->markComponentToRemove<CameraLimits>();
             }
             else
             {
                 directControllable->add<CameraGuide>(player::gCameraGuideWeight);
+                directControllable->add<CameraLimits>(player::gCameraLimits[0], player::gCameraLimits[1]);
+        
             }
         }
 

--- a/src/app/grapkimbo/Systems/Debug/DirectControl.cpp
+++ b/src/app/grapkimbo/Systems/Debug/DirectControl.cpp
@@ -29,7 +29,7 @@ void DirectControl::update(const GrapitoTimer aTimer, const GameInputState & aIn
             }
             else
             {
-                directControllable->add<CameraGuide>(player::gCameraWeight);
+                directControllable->add<CameraGuide>(player::gCameraGuideWeight);
             }
         }
 

--- a/src/app/grapkimbo/Systems/Debug/DirectControl.cpp
+++ b/src/app/grapkimbo/Systems/Debug/DirectControl.cpp
@@ -1,0 +1,51 @@
+#include "DirectControl.h"
+
+#include "../../Configuration.h"
+
+#include "../../Utils/DrawDebugStuff.h"
+
+#include "../../Components/CameraGuide.h"
+
+
+namespace ad {
+namespace grapito {
+namespace debug {
+
+DirectControl::DirectControl(aunteater::EntityManager & aEntityManager) :
+    mDirectControllables{aEntityManager}
+{}
+
+
+void DirectControl::update(const GrapitoTimer aTimer, const GameInputState & aInputState)
+{
+    for (auto directControllable : mDirectControllables)
+    {
+        auto & [controllable, _directControlTag, position] = directControllable;
+        if (aInputState.get(controllable.controller)[R3].positiveEdge())
+        {
+            if (directControllable->has<CameraGuide>())
+            {
+                directControllable->markComponentToRemove<CameraGuide>();
+            }
+            else
+            {
+                directControllable->add<CameraGuide>(player::gCameraWeight);
+            }
+        }
+
+        const ControllerInputState & inputs =
+            aInputState.controllerState[(std::size_t)controllable.controller];
+
+        position.position += aInputState.getRightDirection(controllable.controller)
+                             * debug::gDirectControlSpeed 
+                             * aTimer.delta();
+
+        math::Rectangle<float> outline{position.position, debug::gDirectControlDrawSize};
+        debugDrawer->drawOutline(ad::debug::Rectangle{outline.centered(), debug::gDirectControlDrawColor});
+    }
+}
+
+
+} // namespace debug
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Systems/Debug/DirectControl.h
+++ b/src/app/grapkimbo/Systems/Debug/DirectControl.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Components/Controllable.h>
+#include <Components/Position.h>
+#include <Components/Debug/DirectControlTag.h>
+
+#include <aunteater/EntityManager.h>
+#include <aunteater/FamilyHelp.h>
+#include <aunteater/System.h>
+
+
+namespace ad {
+namespace grapito {
+namespace debug {
+
+
+using DirectControllable = aunteater::Archetype<Controllable, DirectControlTag, Position>;
+
+
+class DirectControl : public aunteater::System<GrapitoTimer, GameInputState>
+{
+public:
+    DirectControl(aunteater::EntityManager & aEntityManager);
+
+    void update(const GrapitoTimer aTimer, const GameInputState & aInputState) override;
+
+private:
+    const aunteater::FamilyHelp<DirectControllable> mDirectControllables;
+
+};
+
+
+} // namespace debug
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Systems/GameRule.cpp
+++ b/src/app/grapkimbo/Systems/GameRule.cpp
@@ -56,7 +56,7 @@ class FreeSoloPhase : public PhaseBase
         StateMachine & aStateMachine) override
     {
         // TODO This should be handled for all active controllers, there might not even be a gamepad.
-        if (aInputs.get(Controller::Gamepad_0)[Start].positiveEdge())
+        if (aInputs.get(Controller::Gamepad_0)[Back].positiveEdge())
         {
             aStateMachine.putNext(getPhase(GameRule::Competition));
             aStateMachine.popState();

--- a/src/app/grapkimbo/Systems/GameRule.cpp
+++ b/src/app/grapkimbo/Systems/GameRule.cpp
@@ -4,6 +4,8 @@
 #include "../Entities.h"
 #include "../Logging.h"
 
+#include "../Utils/Camera.h"
+
 
 namespace ad {
 namespace grapito {
@@ -11,7 +13,8 @@ namespace grapito {
 GameRule::GameRule(aunteater::EntityManager & aEntityManager) :
     mEntityManager{aEntityManager},
     mCompetitors{aEntityManager},
-    mCameras{aEntityManager}
+    mCameras{aEntityManager},
+    mCameraPoints{aEntityManager}
 {}
 
 
@@ -22,14 +25,30 @@ void GameRule::update(const GrapitoTimer, const GameInputState &)
 
     for (auto competitor : mCompetitors)
     {
-        auto & [playerData, geometry] = competitor;            
+        auto & [cameraGuide, playerData, geometry] = competitor;            
         if (geometry.position.y() < (cameraPosition.y() - game::gCompetitorEliminationDistance))
         {
             ADLOG(info)("Player {} eliminated!", playerData.id);
-            // TODO This is a good example of unsafe type system with entities:
+
+            // Patch the camera guide:
+            // A player has a CameraGuide, but also CameraLimits, and the limits override the position computed from the guide.
+            // A fade-out-guide entity will be added to smoothly transition the camera once the competitor is removed, but 
+            // it will not use CameraLimits. So we need to compute the equivalent guide position.
+            Influence cameraInfluence = accumulateCameraGuides(mCameraPoints);
+            Vec2 withoutEliminated = cameraInfluence.accumulatedPosition - weightedGuideContribution(geometry, cameraGuide);
+
+            // The guide position that should be added to keep the camera position unchanged, after the competitor entity is removed.
+            Position2 patchedGuidePosition = (cameraPosition * cameraInfluence.totalWeight - withoutEliminated) / cameraGuide.influence;
+            // The fade-out-guide will be copied from the player CameraGuide: write the result there.
+            // with the added benefit that if several competitors are elmininated in the same step, this will remain correct.
+            cameraGuide.offset = patchedGuidePosition - geometry.position;
+
+            // Remove the player from the game, and 
+            // TODO This is a good example of circumventing the type system with entities:
             // provide a competitor where the archetype of a player is expected.
             kill(competitor, mEntityManager);
         }
+
     }
 }
 

--- a/src/app/grapkimbo/Systems/GameRule.cpp
+++ b/src/app/grapkimbo/Systems/GameRule.cpp
@@ -1,0 +1,38 @@
+#include "GameRule.h"
+
+#include "../Configuration.h"
+#include "../Entities.h"
+#include "../Logging.h"
+
+
+namespace ad {
+namespace grapito {
+
+GameRule::GameRule(aunteater::EntityManager & aEntityManager) :
+    mEntityManager{aEntityManager},
+    mCompetitors{aEntityManager},
+    mCameras{aEntityManager}
+{}
+
+
+void GameRule::update(const GrapitoTimer, const GameInputState &)
+{
+    // There is the one camera
+    Position2 cameraPosition = mCameras.begin()->get<Position>().position;
+
+    for (auto competitor : mCompetitors)
+    {
+        auto & [playerData, geometry] = competitor;            
+        if (geometry.position.y() < (cameraPosition.y() - game::gCompetitorEliminationDistance))
+        {
+            ADLOG(info)("Player {} eliminated!", playerData.id);
+            // TODO This is a good example of unsafe type system with entities:
+            // provide a competitor where the archetype of a player is expected.
+            kill(competitor, mEntityManager);
+        }
+    }
+}
+
+
+} // namespace grapitor
+} // namespace ad

--- a/src/app/grapkimbo/Systems/GameRule.cpp
+++ b/src/app/grapkimbo/Systems/GameRule.cpp
@@ -33,7 +33,7 @@ class CompetitionPhase : public PhaseBase
     using PhaseBase::PhaseBase;
 
     UpdateStatus update(
-        GrapitoTimer &,
+        const GrapitoTimer &,
         const GameInputState & aInputs,
         StateMachine & aStateMachine) override
     {
@@ -51,7 +51,7 @@ class FreeSoloPhase : public PhaseBase
     using PhaseBase::PhaseBase;
 
     UpdateStatus update(
-        GrapitoTimer &,
+        const GrapitoTimer &,
         const GameInputState & aInputs,
         StateMachine & aStateMachine) override
     {
@@ -89,7 +89,7 @@ GameRule::GameRule(aunteater::EntityManager & aEntityManager) :
 
 void GameRule::update(const GrapitoTimer aTimer, const GameInputState & aInput)
 {
-    //mPhaseMachine.update(aTimer, aInput);
+    mPhaseMachine.update(aTimer, aInput);
 }
 
 

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -40,17 +40,24 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
     friend class CompetitionPhase;
 
 public:
-    GameRule(aunteater::EntityManager & aEntityManager);
+    GameRule(aunteater::EntityManager & aEntityManager, std::vector<aunteater::Entity> aPlayers);
 
     void update(const GrapitoTimer aTimer, const GameInputState & aInput) override;
 
 private:
+    /// \brief Remove all competitors from the game.
+    void killAllCompetitors(); // Can you tell I watched squid game recently?
+    /// \brief Apply the elimination rule to each competitor, removing competitors failing the test.
     void eliminateCompetitors();
+
+    void prepareCameraFadeOut(Position2 aCameraPosition, const Position & aGeometry, CameraGuide & aCameraGuide);
 
     aunteater::EntityManager & mEntityManager;
     const aunteater::FamilyHelp<Competitor> mCompetitors;
     const aunteater::FamilyHelp<Camera> mCameras;
     const aunteater::FamilyHelp<CameraPoint> mCameraPoints;
+
+    std::vector<aunteater::Entity> mPlayers;
 
     PhasesArray mPhases;
     StateMachine mPhaseMachine;

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CameraGuidedControl.h" // for Camera archetype
+
+#include "../Components/Position.h"
+#include "../Components/PlayerData.h"
+
+#include <aunteater/EntityManager.h>
+#include <aunteater/FamilyHelp.h>
+#include <aunteater/System.h>
+
+
+namespace ad {
+namespace grapito {
+
+
+using Competitor = aunteater::Archetype<PlayerData, Position>;
+
+
+class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
+{
+public:
+    GameRule(aunteater::EntityManager & aEntityManager);
+
+    void update(const GrapitoTimer, const GameInputState &) override;
+
+private:
+    aunteater::EntityManager & mEntityManager;
+    const aunteater::FamilyHelp<Competitor> mCompetitors;
+    const aunteater::FamilyHelp<Camera> mCameras;
+};
+
+
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -5,9 +5,13 @@
 #include "../Components/Position.h"
 #include "../Components/PlayerData.h"
 
+#include "../Scenery/StateMachine.h"
+
 #include <aunteater/EntityManager.h>
 #include <aunteater/FamilyHelp.h>
 #include <aunteater/System.h>
+
+#include <array>
 
 
 namespace ad {
@@ -19,16 +23,37 @@ using Competitor = aunteater::Archetype<CameraGuide, PlayerData, Position>;
 
 class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
 {
+    enum Phase
+    {
+        FreeSolo,
+        Competition, 
+
+        _End,
+    };
+
+    using PhasesArray = std::array<std::shared_ptr<State>, _End>;
+
+    friend PhasesArray setupGamePhases(GameRule &);
+
+    friend class PhaseBase;
+    friend class FreeSoloPhase;
+    friend class CompetitionPhase;
+
 public:
     GameRule(aunteater::EntityManager & aEntityManager);
 
-    void update(const GrapitoTimer, const GameInputState &) override;
+    void update(const GrapitoTimer aTimer, const GameInputState & aInput) override;
 
 private:
+    void eliminateCompetitors();
+
     aunteater::EntityManager & mEntityManager;
     const aunteater::FamilyHelp<Competitor> mCompetitors;
     const aunteater::FamilyHelp<Camera> mCameras;
     const aunteater::FamilyHelp<CameraPoint> mCameraPoints;
+
+    PhasesArray mPhases;
+    StateMachine mPhaseMachine;
 };
 
 

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -14,7 +14,7 @@ namespace ad {
 namespace grapito {
 
 
-using Competitor = aunteater::Archetype<PlayerData, Position>;
+using Competitor = aunteater::Archetype<CameraGuide, PlayerData, Position>;
 
 
 class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
@@ -28,6 +28,7 @@ private:
     aunteater::EntityManager & mEntityManager;
     const aunteater::FamilyHelp<Competitor> mCompetitors;
     const aunteater::FamilyHelp<Camera> mCameras;
+    const aunteater::FamilyHelp<CameraPoint> mCameraPoints;
 };
 
 

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -45,6 +45,9 @@ public:
     void update(const GrapitoTimer aTimer, const GameInputState & aInput) override;
 
 private:
+    /// \brief Reset all competitors to their initial state.
+    void resetCompetitors();
+
     /// \brief Remove all competitors from the game.
     void killAllCompetitors(); // Can you tell I watched squid game recently?
     /// \brief Apply the elimination rule to each competitor, removing competitors failing the test.

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -27,6 +27,7 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
     {
         FreeSolo,
         Competition, 
+        Congratulation,
 
         _End,
     };
@@ -38,6 +39,7 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
     friend class PhaseBase;
     friend class FreeSoloPhase;
     friend class CompetitionPhase;
+    friend class CongratulationPhase;
 
 public:
     GameRule(aunteater::EntityManager & aEntityManager, std::vector<aunteater::Entity> aPlayers);
@@ -50,8 +52,10 @@ private:
 
     /// \brief Remove all competitors from the game.
     void killAllCompetitors(); // Can you tell I watched squid game recently?
+
     /// \brief Apply the elimination rule to each competitor, removing competitors failing the test.
-    void eliminateCompetitors();
+    /// \return The number of competitors remaining in the game after this step of eliminations.
+    std::size_t eliminateCompetitors();
 
     void prepareCameraFadeOut(Position2 aCameraPosition, const Position & aGeometry, CameraGuide & aCameraGuide);
 

--- a/src/app/grapkimbo/Systems/Hud.cpp
+++ b/src/app/grapkimbo/Systems/Hud.cpp
@@ -1,0 +1,32 @@
+#include "Hud.h"
+
+#include "../Configuration.h"
+
+
+namespace ad {
+namespace grapito {
+
+
+Hud::Hud(aunteater::EntityManager & aEntityManager,
+         const filesystem::path & aFontPath,
+         std::shared_ptr<graphics::AppInterface> aAppInterface) :
+    mHudTexts{aEntityManager},
+    mTexting{aFontPath, hud::gTextHeight, hud::gViewedHeight, std::move(aAppInterface)}
+{}
+
+
+void Hud::update(const GrapitoTimer aTimer, const GameInputState &)
+{
+    graphics::Texting::Mapping strings;
+
+    for(const auto & [screenPosition, text] : mHudTexts)
+    {
+        mTexting.prepareString(text.message, screenPosition.position, strings);
+    }
+    mTexting.updateInstances(strings);
+    mTexting.render();
+}
+
+
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Systems/Hud.h
+++ b/src/app/grapkimbo/Systems/Hud.h
@@ -1,0 +1,40 @@
+#pragma once
+
+
+#include "../Input.h"
+
+#include "../Components/ScreenPosition.h"
+#include "../Components/Text.h"
+
+#include <aunteater/EntityManager.h>
+#include <aunteater/FamilyHelp.h>
+#include <aunteater/System.h>
+
+#include <graphics/Texting.h>
+
+
+namespace ad {
+namespace grapito {
+
+
+using HudText = aunteater::Archetype<ScreenPosition, Text>;
+
+
+class Hud : public aunteater::System<GrapitoTimer, GameInputState>
+{
+public:
+    Hud(aunteater::EntityManager & aEntityManager,
+        const filesystem::path & aFontPath,
+        std::shared_ptr<graphics::AppInterface> aAppInterface);
+
+    void update(const GrapitoTimer, const GameInputState &) override;
+
+private:
+    const aunteater::FamilyHelp<HudText> mHudTexts;
+
+    graphics::Texting mTexting;
+};
+
+
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Systems/Render.cpp
+++ b/src/app/grapkimbo/Systems/Render.cpp
@@ -1,14 +1,15 @@
 #include "Render.h"
 
 #include "../Configuration.h"
+
+#include "../Utils/Camera.h"
 #include "../Utils/DrawDebugStuff.h"
 #include "../Utils/RopeUtilities.h"
-#include <graphics/TrivialPolygon.h>
 
+#include <graphics/TrivialPolygon.h>
 #include <graphics/CameraUtilities.h>
 
 #include <math/Transformations.h>
-#include <math/VectorUtilities.h>
 
 
 namespace ad {
@@ -139,10 +140,9 @@ void Render::update(const GrapitoTimer aTimer, const GameInputState &)
 
     for(const auto & [cameraTag, geometry] : mCameras)
     {
-        auto viewed = math::Rectangle<GLfloat>{
-            static_cast<math::Position<2, GLfloat>>(geometry.position),
-            math::makeSizeFromHeight(render::gViewedHeight, math::getRatio<GLfloat>(mAppInterface->getWindowSize()))
-        }.centered();
+        math::Rectangle<GLfloat> viewed = 
+            getViewedRectangle(geometry.position,
+                               math::getRatio<GLfloat>(mAppInterface->getWindowSize()));
         setViewedRectangle(mTrivialShaping, viewed);
         setViewedRectangle(mTrivialLineStrip, viewed);
         setViewedRectangle(mTrivialPolygon, viewed);

--- a/src/app/grapkimbo/Utils/Camera.h
+++ b/src/app/grapkimbo/Utils/Camera.h
@@ -1,0 +1,24 @@
+#pragma once
+
+
+#include "../commons.h"
+#include "../Configuration.h"
+
+#include <math/VectorUtilities.h>
+
+
+namespace ad {
+namespace grapito {
+
+
+inline math::Rectangle<GLfloat> getViewedRectangle(Position2 aCameraPosition, float aViewportRatio)
+{
+    return math::Rectangle<GLfloat>{
+        aCameraPosition,
+        math::makeSizeFromHeight(render::gViewedHeight, aViewportRatio)
+    }.centered();
+}
+
+
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/Utils/Camera.h
+++ b/src/app/grapkimbo/Utils/Camera.h
@@ -20,5 +20,11 @@ inline math::Rectangle<GLfloat> getViewedRectangle(Position2 aCameraPosition, fl
 }
 
 
+inline Vec2 weightedGuideContribution(const Position & aGeometry, const CameraGuide & aCameraGuide)
+{
+    Position2 guidePosition = aGeometry.position + aCameraGuide.offset;
+    return guidePosition.as<math::Vec>() * aCameraGuide.influence;
+}
+
 } // namespace grapito
 } // namespace ad

--- a/src/app/grapkimbo/Utils/CompositeTransition.h
+++ b/src/app/grapkimbo/Utils/CompositeTransition.h
@@ -84,6 +84,12 @@ public:
         return mCompleted;
     }
 
+    void reset()
+    {
+        mCurrent = 0;
+        mLocalTime = 0;
+        mCompleted = false;
+    }
 
 private:
     T_parameter getLastEndTime()

--- a/src/app/grapkimbo/Utils/DrawDebugStuff.cpp
+++ b/src/app/grapkimbo/Utils/DrawDebugStuff.cpp
@@ -38,6 +38,24 @@ namespace ad
             });
         }
 
+        void DrawDebugStuff::drawCross(const Cross & aCross)
+        {
+            grapito::Vec2 slashOffset{aCross.size / 2.f, aCross.size / 2.f};
+            grapito::Vec2 antislashOffset{aCross.size / 2.f, -aCross.size / 2.f};
+            mLines.push_back({
+                aCross.center - slashOffset,
+                aCross.center + slashOffset,
+                0.,
+                aCross.color,
+            });
+            mLines.push_back({
+                aCross.center - antislashOffset,
+                aCross.center + antislashOffset,
+                0.,
+                aCross.color,
+            });
+        }
+
         void DrawDebugStuff::drawLine(Line aLine)
         {
             mLines.push_back(aLine);

--- a/src/app/grapkimbo/Utils/DrawDebugStuff.h
+++ b/src/app/grapkimbo/Utils/DrawDebugStuff.h
@@ -104,6 +104,13 @@ namespace ad
             math::sdr::Rgb color;
         };
 
+        struct Cross
+        {
+            math::Position<2, GLfloat> center;
+            float size;
+            math::sdr::Rgb color;
+        };
+
         class DrawDebugStuff
         {
             public:
@@ -118,6 +125,7 @@ namespace ad
                 void drawPoint(Point aPoint);
                 //void drawArrow(Arrow aArrow);
                 //void drawPoint(Point aPoint);
+                void drawCross(const Cross & aCross);
                 void render();
                 void clear();
 
@@ -144,4 +152,4 @@ namespace ad
     /// (it might only matter when we go down the concurrency path)
     /// TODO rename to gDebugDrawer
     inline std::unique_ptr<debug::DrawDebugStuff> debugDrawer;
-} // namespace
+} // namespace ad

--- a/src/app/grapkimbo/Utils/PhysicsMathUtilities.h
+++ b/src/app/grapkimbo/Utils/PhysicsMathUtilities.h
@@ -13,6 +13,8 @@ static inline float twoDVectorCross(Vec2 v, Vec2 w)
     return v.x() * w.y() - v.y() * w.x();
 }
 
+// TODO Franz: Why are the free functions static?
+// 
 // Solve m * x = v
 static inline Vec2 solveMatrix(math::Matrix<2, 2, float> m, Vec2 v)
 {

--- a/src/app/grapkimbo/commons.h
+++ b/src/app/grapkimbo/commons.h
@@ -17,6 +17,8 @@ using Vec2 = math::Vec<2, float>;
 using Vec3 = math::Vec<3, float>;
 using Position2 = math::Position<2, float>;
 using Position3 = math::Position<3, float>;
+using Size2 = math::Size<2, float>;
+using Size3 = math::Size<3, float>;
 using Rectangle = math::Rectangle<float>;
 
 using GrapitoTimer = aunteater::Timer_base<float>;


### PR DESCRIPTION
closes #85

- Add a command line option to skip splash screens.
- Tweak game configuration: smaller player, more grapple impulse.
- Adapt level layout.
- Implement direct control system, used to control a camera guide.
- Handle Camera following the action, with upper and lower limits.
- Start GameRule system, eliminating players falling below camera limit.
- Extend CameraGuide completion behaviours with "RemoveEntity".
- Fix the fade-out camera guide added on competitor elimination.
- WIP Introduce game phases in GameRule system.
- Propagate const-ness of timer to StateMachine::update(). This way, it can be used within systems update().
- Change the "launch competition" to gamepad back button.
- Factorize the complete camera fade-out guide in a GameRule method.
- Implement HUD text.
- Implement basic game phases, allowing to climb several games.
- [conan] Update graphics reference (fix graphics#24 multiple sprites).
