### PR TITLE
topic/grapito#88 gamepad menu control

### DIFF
--- a/src/app/grapkimbo/CMakeLists.txt
+++ b/src/app/grapkimbo/CMakeLists.txt
@@ -88,6 +88,7 @@ set(${TARGET_NAME}_HEADERS
     Utils/CompositeTransition.h
     Utils/DrawDebugStuff.h
     Utils/HomogeneousTransformation.h
+    Utils/MenuControls.h
     Utils/PhysicsMathUtilities.h
     Utils/PhysicsStructs.h
     Utils/Player.h

--- a/src/app/grapkimbo/Input.cpp
+++ b/src/app/grapkimbo/Input.cpp
@@ -91,10 +91,10 @@ void readJoystick(int aGlfwJoystickId, const GamepadInputConfig & aConfig, Contr
                 handleButtonEdges(aState[mapping->command], gamepadState.buttons[mapping->glGamePadCode]);
                 break;
             case Axis:
-                aState[mapping->command].state = + gamepadState.axes[mapping->glGamePadCode];
+                aState[mapping->command].axis() = + gamepadState.axes[mapping->glGamePadCode];
                 break;
             case AxisInverted:
-                aState[mapping->command].state = - gamepadState.axes[mapping->glGamePadCode];
+                aState[mapping->command].axis() = - gamepadState.axes[mapping->glGamePadCode];
                 break;
             }
         }
@@ -106,8 +106,8 @@ void readMouse(ControllerInputState & aState, graphics::ApplicationGlfw & aAppli
     float xPos, yPos;
     aApplication.getMousePos(xPos, yPos);
 
-    aState[MouseXPos].state = xPos;
-    aState[MouseYPos].state = yPos;
+    aState[MouseXPos].axis() = xPos;
+    aState[MouseYPos].axis() = yPos;
 }
 
 

--- a/src/app/grapkimbo/Input.h
+++ b/src/app/grapkimbo/Input.h
@@ -113,6 +113,12 @@ struct InputState
         return std::get<ButtonStatus>(state) == ButtonStatus::NegativeEdge;
     }
 
+    operator ButtonStatus() const
+    {
+        return std::get<ButtonStatus>(state);
+    }
+
+
     operator float() const
     {
         return std::get<AxisStatus>(state);
@@ -146,11 +152,17 @@ constexpr bool isGamepad(Controller aController);
 
 bool isGamepadPresent(Controller aController);
 
+enum class AxisSign
+{
+    Positive,
+    Negative
+};
 
 struct GameInputState
 {
     void readAll(graphics::ApplicationGlfw & aApplication);
     float asAxis(Controller aController, Command aNegativeButton, Command aPositiveButton, Command aGamepadAxis) const;
+    ButtonStatus asButton(Controller aController, Command aButton, Command aGamepadAxis, AxisSign aSign, float aDeadZone) const;
     math::Vec<2, float> asDirection(Controller aController,
                                     Command aHorizontalAxis,
                                     Command aVerticalAxis,

--- a/src/app/grapkimbo/Input.h
+++ b/src/app/grapkimbo/Input.h
@@ -73,13 +73,34 @@ enum ButtonStatus
     PositiveEdge, // just pressed
 };
 
+
+struct AxisStatus
+{
+    float previous{0.f};
+    float current{0.f};
+
+    AxisStatus & operator=(float aNewValue)
+    {
+        previous = current;
+        current = aNewValue;
+        return *this;
+    }
+
+    operator float () const
+    {
+        return current;
+    }
+};
+
 struct InputState
 {
-    std::variant<ButtonStatus, float> state;
+    std::variant<AxisStatus, ButtonStatus> state;
 
     operator bool() const
     {
-        return std::get<ButtonStatus>(state) >= ButtonStatus::Pressed;
+        // By comparing to a variant, it will return false if the current alternative is not a ButtonStatus
+        // (instead of throwing bad_variant_access).
+        return state >= std::variant<AxisStatus, ButtonStatus>{ButtonStatus::Pressed};
     }
 
     bool positiveEdge() const
@@ -94,7 +115,12 @@ struct InputState
 
     operator float() const
     {
-        return std::get<float>(state);
+        return std::get<AxisStatus>(state);
+    }
+
+    AxisStatus & axis()
+    {
+        return std::get<AxisStatus>(state);
     }
 };
 

--- a/src/app/grapkimbo/Scenery/GameScene.cpp
+++ b/src/app/grapkimbo/Scenery/GameScene.cpp
@@ -5,6 +5,8 @@
 #include "../Configuration.h"
 #include "../Logging.h"
 #include "../TopLevelStates.h"
+
+#include "../Utils/MenuControls.h"
     
 
 namespace ad {
@@ -23,8 +25,7 @@ UpdateStatus GameScene::update(
     const GameInputState & aInputs,
     StateMachine & aStateMachine)
 {
-    InputState gamePause = aInputs.get(Controller::KeyboardMouse)[Command::Start];
-    if (gamePause.positiveEdge())
+    if (isPositiveEdge(aInputs, Start))
     {
         aStateMachine.pushState(setupPauseMenu(mContext, mAppInterface, shared_from_this()));
         // Causes troubles with detection of next press of pause button

--- a/src/app/grapkimbo/Scenery/MenuScene.cpp
+++ b/src/app/grapkimbo/Scenery/MenuScene.cpp
@@ -7,6 +7,7 @@
 #include "../Logging.h"
 
 #include "../Utils/DrawDebugStuff.h"
+#include "../Utils/MenuControls.h"
 
 #include <math/VectorUtilities.h>
 
@@ -51,17 +52,17 @@ UpdateStatus MenuScene::update(
     // Note: The logic eagerly re-creates the text buffers each time the selection change.
     // This is currently not necessary, but make the logic a bit simpler.
 
-    if (aInputs.get(Controller::KeyboardMouse)[Command::Up].positiveEdge())
+    if (isPositiveEdge(aInputs, Up, LeftVerticalAxis, AxisSign::Positive))
     {
         mMenu.mSelected = std::min(mMenu.mSelected - 1, mMenu.size() - 1);
         updateMenuBuffers();
     }
-    else if (aInputs.get(Controller::KeyboardMouse)[Command::Down].positiveEdge())
+    else if (isPositiveEdge(aInputs, Down, LeftVerticalAxis, AxisSign::Negative))
     {
         mMenu.mSelected = (mMenu.mSelected + 1) % mMenu.size();
         updateMenuBuffers();
     }
-    else if (aInputs.get(Controller::KeyboardMouse)[Command::Start].positiveEdge())
+    else if (isPositiveEdge(aInputs, Start))
     {
         mMenu.selected().mCallback(aStateMachine, mAppInterface);
         // When the menu is poping itself, the OpenGL is issuing an error when return SwapBuffers:

--- a/src/app/grapkimbo/Utils/MenuControls.h
+++ b/src/app/grapkimbo/Utils/MenuControls.h
@@ -1,0 +1,41 @@
+#pragma once
+
+
+#include "../Input.h"
+
+
+namespace ad {
+namespace grapito {
+
+
+static const std::initializer_list<Controller> gMenuControllers = {Controller::KeyboardMouse, Controller::Gamepad_0}; 
+
+
+inline bool isPositiveEdge(const GameInputState & aInputs, Command aButton, Command aAxis, AxisSign aSign)
+{
+    for (auto controller : gMenuControllers)
+    {
+        if (aInputs.asButton(controller, aButton, aAxis, aSign, controller::gDeadzone) == PositiveEdge)
+        {
+            return true;
+        }
+    }
+    return false;
+};
+
+
+inline bool isPositiveEdge(const GameInputState & aInputs, Command aButton)
+{
+    for (auto controller : gMenuControllers)
+    {
+        if (aInputs.get(controller)[aButton].positiveEdge())
+        {
+            return true;
+        }
+    }
+    return false;
+};
+
+
+} // namespace grapito
+} // namespace ad

--- a/src/app/grapkimbo/main.cpp
+++ b/src/app/grapkimbo/main.cpp
@@ -23,6 +23,8 @@
 #include <iostream>
 
 
+//#define EN_MODE_LAFF
+
 using namespace ad;
 using namespace ad::grapito;
 
@@ -73,7 +75,11 @@ int main(int argc, const char ** argv)
         DebugUI debugUI;
 
         std::shared_ptr<Context> context = 
+#if defined(EN_MODE_LAFF)
+            std::make_shared<Context>(filesystem::path{"assets/"});
+#else
             std::make_shared<Context>(gRepositoryRoot / filesystem::path{"../grapito_media/assets/"});
+#endif
         context->locale.setLanguage("es");
 
         StateMachine topLevelFlow;


### PR DESCRIPTION
closes #88

- Add "EN_MODE_LAFF" switch to manually control building portable app.
- Store previous value in InputState alternative for axis.
- Provide menu control via both Keyboard and first gamepad.
