### PR TITLE
topic/grapito#90 analog speed control

### DIFF
--- a/src/app/grapkimbo/Animation/AnimationStateMachine.cpp
+++ b/src/app/grapkimbo/Animation/AnimationStateMachine.cpp
@@ -6,7 +6,7 @@ namespace grapito {
 
 
 std::optional<AnimatedSprite> AnimationStateMachine::update(PlayerAnimation & aState,
-                                                            const AnimatedSprite & aAnimation,
+                                                            AnimatedSprite & aAnimation,
                                                             const AccelAndSpeed & aAccelAndSpeed,
                                                             const PlayerData & aPlayerData)
 {

--- a/src/app/grapkimbo/Animation/AnimationStateMachine.h
+++ b/src/app/grapkimbo/Animation/AnimationStateMachine.h
@@ -25,7 +25,7 @@ struct AnimationState
 {
     // TODO might probably be free functions' pointers
     AnimatedSprite mAnimatedSprite;
-    std::function<std::optional<PlayerAnimation>(const AnimatedSprite & aAnimation,
+    std::function<std::optional<PlayerAnimation>(AnimatedSprite & aAnimation,
                                                  const AccelAndSpeed & aAccelAndSpeed,
                                                  const PlayerData & aPlayerData)> mUpdate;
 };
@@ -40,7 +40,7 @@ class AnimationStateMachine
 {
 public:
     std::optional<AnimatedSprite> update(PlayerAnimation & aState, 
-                                         const AnimatedSprite & aAnimation,
+                                         AnimatedSprite & aAnimation,
                                          const AccelAndSpeed & aAccelAndSpeed,
                                          const PlayerData & aPlayerData);
 

--- a/src/app/grapkimbo/Components/AnimatedSprite.h
+++ b/src/app/grapkimbo/Components/AnimatedSprite.h
@@ -28,10 +28,17 @@ struct AnimatedSprite : public aunteater::Component<AnimatedSprite>
         horizontalMirroring{aHorizontalMirroring}
     {}
 
+    float advance(float aDelta)
+    {
+        return parameter(aDelta * parameterAdvanceSpeed);
+    }
+
     StringId animation = StringId::Null();  
+    float parameterAdvanceSpeed{1.f};
     // This provides type erasure for the parameter animation
-    std::function<float(float)> parameter;
     bool horizontalMirroring{false};
+private:
+    std::function<float(float)> parameter;
 };
 
 

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -77,7 +77,7 @@ aunteater::Entity makePlayer(int aIndex,
         .add<Mass>(player::gMass)
         .add<PlayerData>(aIndex, aColor)
         .add<Position>(Position2{3.f, 3.f}, player::gSize) // The position will be set by pendulum simulation
-        .add<VisualRectangle>(aColor)
+        //.add<VisualRectangle>(aColor)
         .add<VisualSprite>() // handled by animation system
     ;
 

--- a/src/app/grapkimbo/Systems/Control.cpp
+++ b/src/app/grapkimbo/Systems/Control.cpp
@@ -45,13 +45,12 @@ void Control::update(const GrapitoTimer, const GameInputState & aInputState)
             horizontalAxis = direction.x();
         }
 
-        // TODO FP: Something more robust to determine axis sign.
-        float horizontalAxisSign = horizontalAxis == 0 ? 1.f : (horizontalAxis / std::abs(horizontalAxis));
-
-        float groundSpeedAccelFactor = 1.f / player::gGroundNumberOfAccelFrame;
         float groundFriction = 1.f / player::gGroundNumberOfSlowFrame;
         float airSpeedAccelFactor = 1.f / player::gAirNumberOfAccelFrame;
         float airFriction = 1.f / player::gAirNumberOfSlowFrame;
+
+        const float groundMaxFrameAcceleration = player::gGroundSpeed / player::gGroundNumberOfAccelFrame;
+        const float airMaxFrameAcceleration = player::gAirSpeed / player::gAirNumberOfAccelFrame;
 
         if (playerData.state & PlayerCollisionState_Grounded)
         {
@@ -59,8 +58,9 @@ void Control::update(const GrapitoTimer, const GameInputState & aInputState)
             {
                 if (std::abs(aas.speed.x()) <= player::gGroundSpeed)
                 {
-                    aas.speed += horizontalAxisSign * player::gGroundSpeed * groundSpeedAccelFactor * Vec2{1.f, 0.f};
-                    aas.speed.x() = std::max(std::min(player::gGroundSpeed, aas.speed.x()), -player::gGroundSpeed);
+                    float targetSpeed = horizontalAxis * player::gGroundSpeed;
+                    float speedChange = targetSpeed - aas.speed.x();
+                    aas.speed += std::clamp(speedChange, -groundMaxFrameAcceleration, groundMaxFrameAcceleration) * Vec2{1.f, 0.f};
                 }
                 else
                 {
@@ -83,8 +83,9 @@ void Control::update(const GrapitoTimer, const GameInputState & aInputState)
             {
                 if (std::abs(aas.speed.x()) <= player::gAirSpeed)
                 {
-                    aas.speed += horizontalAxisSign * player::gAirSpeed * airSpeedAccelFactor * Vec2{1.f, 0.f};
-                    aas.speed.x() = std::max(std::min(player::gAirSpeed, aas.speed.x()), -player::gAirSpeed);
+                    float targetSpeed = horizontalAxis * player::gAirSpeed;
+                    float speedChange = targetSpeed - aas.speed.x();
+                    aas.speed += std::clamp(speedChange, -airMaxFrameAcceleration, airMaxFrameAcceleration) * Vec2{1.f, 0.f};
                 }
                 else
                 {


### PR DESCRIPTION
closes #90

- Implement analog control of player movement on X axis.
- Disable players VisualRectangle.
- The run animation playback speed is proportional to movement speed.
