### PR TITLE
topic/grapito#92 jump airborne

### DIFF
--- a/src/app/grapkimbo/Components/PlayerData.h
+++ b/src/app/grapkimbo/Components/PlayerData.h
@@ -23,10 +23,12 @@ constexpr PlayerCollisionStateFlag PlayerCollisionState_Jumping = 0b10000;
 constexpr PlayerCollisionStateFlag PlayerCollisionState_Grappling = 0b100000;
 constexpr PlayerCollisionStateFlag PlayerCollisionState_OffGrapple = 0b1000000;
 
+// TODO FP Why two different typedefs here?
 typedef int ControlStateFlags;
 typedef int ControlStateFlag;
 
 constexpr ControlStateFlag ControlState_Throwing = 0b1;
+// TODO FP The grapple is not necessarily attached though? (Might be out without connection)
 constexpr ControlStateFlag ControlState_Attached = 0b10;
 
 constexpr Vec2 PlayerGroundedNormal = {0.f, 1.f};

--- a/src/app/grapkimbo/Components/PlayerData.h
+++ b/src/app/grapkimbo/Components/PlayerData.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "commons.h"
+#include "../commons.h"
+#include "../Configuration.h"
 
 #include "../Animation/PlayerAnimation.h"
 
@@ -20,6 +21,7 @@ constexpr PlayerCollisionStateFlag PlayerCollisionState_Walled = 0b10;
 constexpr PlayerCollisionStateFlag PlayerCollisionState_WalledRight = 0b100;
 constexpr PlayerCollisionStateFlag PlayerCollisionState_WalledLeft = 0b1000;
 constexpr PlayerCollisionStateFlag PlayerCollisionState_Jumping = 0b10000;
+// TODO FP These seem not used?
 constexpr PlayerCollisionStateFlag PlayerCollisionState_Grappling = 0b100000;
 constexpr PlayerCollisionStateFlag PlayerCollisionState_OffGrapple = 0b1000000;
 
@@ -51,6 +53,7 @@ struct PlayerData : public aunteater::Component<PlayerData>
     ControlStateFlags controlState = 0;
 
     int wallClingFrameCounter = 0;
+    int airborneJumpsLeft = player::gAirborneJumps;
 
     aunteater::weak_entity grapple = nullptr;
     aunteater::weak_entity grappleAttachment = nullptr;

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -43,6 +43,7 @@ namespace hud
 
 namespace player
 {
+    const int gAirborneJumps = 1;
     const Vec2 gCameraGuideOffset{0.f, 15.f};
     const float gCameraGuideWeight = 1.f;
     const std::array<float, 2> gCameraLimits{7.f, -2.5f};

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -47,6 +47,7 @@ namespace player
     const Vec2 gCameraGuideOffset{0.f, 15.f};
     const float gCameraGuideWeight = 1.f;
     const std::array<float, 2> gCameraLimits{7.f, -2.5f};
+    const float gDetachSpeedBoostFactor = 1.5f;
     const float gIdleSpeedLimit = 1;
     const math::Size<2, float> gSize = math::Size<2, float>{5.6f, 7.5f} / gGigantismDampeningFactor;
     const float gGrappleFriction = 0.5f;

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -95,6 +95,7 @@ namespace physic
 
 namespace player
 {
+    extern const int gAirborneJumps;
     extern const Vec2 gCameraGuideOffset;
     extern const float gCameraGuideWeight;
     extern const std::array<float, 2> gCameraLimits;

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -99,6 +99,7 @@ namespace player
     extern const Vec2 gCameraGuideOffset;
     extern const float gCameraGuideWeight;
     extern const std::array<float, 2> gCameraLimits;
+    extern const float gDetachSpeedBoostFactor;
     constexpr float gMass = 80.f;
     extern const math::Size<2, float> gSize;
     constexpr float gInitialRopeLength = 3.f;

--- a/src/app/grapkimbo/Input.cpp
+++ b/src/app/grapkimbo/Input.cpp
@@ -182,7 +182,8 @@ void GameInputState::readAll(graphics::ApplicationGlfw & aApplication)
 float GameInputState::asAxis(Controller aController,
                              Command aNegativeButton,
                              Command aPositiveButton,
-                             Command aGamepadAxis) const
+                             Command aGamepadAxis,
+                             float aDeadzone) const
 {
     ControllerInputState input = get(aController);
     float axis = 0.;
@@ -200,6 +201,7 @@ float GameInputState::asAxis(Controller aController,
     else
     {
         axis = input[aGamepadAxis];
+        axis = std::abs(axis) > aDeadzone ? axis : 0.f;
     }
     return axis;
 }
@@ -209,23 +211,23 @@ ButtonStatus GameInputState::asButton(Controller aController,
                                       Command aButton,
                                       Command aGamepadAxis,
                                       AxisSign aSign,
-                                      float aDeadZone) const
+                                      float aDeadzone) const
 {
-    assert(aDeadZone >= 0.f);
+    assert(aDeadzone >= 0.f);
 
     ControllerInputState input = get(aController);
     if (isGamepad(aController))
     {
-        auto isPressed = [aSign, aDeadZone](float aValue) -> bool
+        auto isPressed = [aSign, aDeadzone](float aValue) -> bool
         {
             switch(aSign)
             {
                 case AxisSign::Negative:
-                    return aValue < -aDeadZone;
+                    return aValue < -aDeadzone;
                 // For invalid values, consider it positive case the default
                 case AxisSign::Positive:
                 default:
-                    return aValue > aDeadZone;
+                    return aValue > aDeadzone;
             }
         };
 
@@ -252,7 +254,7 @@ T filterDeadzoneSingleAxis(T aValue, T aDeadzone, T aDefault = 0)
 math::Vec<2, float> GameInputState::asDirection(Controller aController,
                                                 Command aHorizontalAxis,
                                                 Command aVerticalAxis,
-                                                float aDeadZone) const
+                                                float aDeadzone) const
 {
     if (! isGamepad(aController))
     {
@@ -261,14 +263,14 @@ math::Vec<2, float> GameInputState::asDirection(Controller aController,
 
     ControllerInputState input = get(aController);
     math::Vec<2, float> candidate{input[aHorizontalAxis], input[aVerticalAxis]};
-    return candidate.getNorm() > aDeadZone ? candidate : math::Vec<2, float>::Zero();
+    return candidate.getNorm() > aDeadzone ? candidate : math::Vec<2, float>::Zero();
 }
 
 math::Vec<2, float> GameInputState::asDirection(Controller aController,
     Command aHorizontalAxis,
     Command aVerticalAxis,
-    float aHorizontalDeadZone,
-    float aVerticalDeadZone) const
+    float aHorizontalDeadzone,
+    float aVerticalDeadzone) const
 {
     if (!isGamepad(aController))
     {
@@ -277,8 +279,8 @@ math::Vec<2, float> GameInputState::asDirection(Controller aController,
 
     ControllerInputState input = get(aController);
     math::Vec<2, float> candidate{ input[aHorizontalAxis], input[aVerticalAxis] };
-    candidate.x() = std::abs(candidate.x()) > aHorizontalDeadZone ? candidate.x() : 0.f;
-    candidate.y() = std::abs(candidate.y()) > aVerticalDeadZone ? candidate.y() : 0.f;
+    candidate.x() = std::abs(candidate.x()) > aHorizontalDeadzone ? candidate.x() : 0.f;
+    candidate.y() = std::abs(candidate.y()) > aVerticalDeadzone ? candidate.y() : 0.f;
     return candidate;
 }
 

--- a/src/app/grapkimbo/Input.h
+++ b/src/app/grapkimbo/Input.h
@@ -175,26 +175,26 @@ struct GameInputState
     GameInputState();
 
     void readAll(graphics::ApplicationGlfw & aApplication);
-    float asAxis(Controller aController, Command aNegativeButton, Command aPositiveButton, Command aGamepadAxis) const;
-    ButtonStatus asButton(Controller aController, Command aButton, Command aGamepadAxis, AxisSign aSign, float aDeadZone) const;
+    float asAxis(Controller aController, Command aNegativeButton, Command aPositiveButton, Command aGamepadAxis, float aDeadzone = 0.f) const;
+    ButtonStatus asButton(Controller aController, Command aButton, Command aGamepadAxis, AxisSign aSign, float aDeadzone) const;
     math::Vec<2, float> asDirection(Controller aController,
                                     Command aHorizontalAxis,
                                     Command aVerticalAxis,
-                                    float aDeadZone) const;
+                                    float aDeadzone) const;
     math::Vec<2, float> asDirection(Controller aController,
                                     Command aHorizontalAxis,
                                     Command aVerticalAxis,
-                                    float aHorizontalDeadZone,
-                                    float aVerticalDeadZone) const;
+                                    float aHorizontalDeadzone,
+                                    float aVerticalDeadzone) const;
 
     const ControllerInputState & get(Controller aController) const
     { return controllerState[(std::size_t)aController]; }
 
-    math::Vec<2, float> getLeftDirection(Controller aController, float aDeadZone = 0.2) const
-    { return asDirection(aController, LeftHorizontalAxis, LeftVerticalAxis, aDeadZone); }
+    math::Vec<2, float> getLeftDirection(Controller aController, float aDeadzone = 0.2) const
+    { return asDirection(aController, LeftHorizontalAxis, LeftVerticalAxis, aDeadzone); }
 
-    math::Vec<2, float> getRightDirection(Controller aController, float aDeadZone = 0.2) const
-    { return asDirection(aController, RightHorizontalAxis, RightVerticalAxis, aDeadZone); }
+    math::Vec<2, float> getRightDirection(Controller aController, float aDeadzone = 0.2) const
+    { return asDirection(aController, RightHorizontalAxis, RightVerticalAxis, aDeadzone); }
 
     std::array<ControllerInputState, gControllerCount> controllerState;
 };

--- a/src/app/grapkimbo/Systems/Control.cpp
+++ b/src/app/grapkimbo/Systems/Control.cpp
@@ -41,18 +41,11 @@ void Control::update(const GrapitoTimer, const GameInputState & aInputState)
     //
     for(auto & [controllable, geometry, aas, mass, playerData] :  mCartesianControllables)
     {
-        const ControllerInputState & inputs = aInputState.controllerState[(std::size_t)controllable.controller];
-        float horizontalAxis;
-
-        if (controllable.controller == Controller::KeyboardMouse)
-        {
-            horizontalAxis = aInputState.asAxis(controllable.controller, Left, Right, LeftHorizontalAxis);
-        }
-        else
-        {
-            Vec2 direction = aInputState.asDirection(controllable.controller, LeftHorizontalAxis, LeftVerticalAxis, controller::gHorizontalDeadZone, 0.f);
-            horizontalAxis = direction.x();
-        }
+        const ControllerInputState & inputs = aInputState.get(controllable.controller);
+        float horizontalAxis = 
+            aInputState.asAxis(controllable.controller, 
+                               Left, Right, 
+                               LeftHorizontalAxis, controller::gHorizontalDeadZone);
 
         //
         // Reset airborn jumps
@@ -80,6 +73,7 @@ void Control::update(const GrapitoTimer, const GameInputState & aInputState)
                 }
                 else
                 {
+                    // TODO FP Magic number
                     aas.accel -= aas.speed * 5.f;
                 }
             }

--- a/src/app/grapkimbo/Systems/Control.h
+++ b/src/app/grapkimbo/Systems/Control.h
@@ -20,7 +20,6 @@ namespace grapito
 {
 
 typedef aunteater::Archetype<Controllable, Position, AccelAndSpeed, Mass, PlayerData> CartesianControlled;
-typedef aunteater::Archetype<Controllable, AccelAndSpeed, PlayerData> PolarControlled;
 typedef aunteater::Archetype<Controllable, AccelAndSpeed, GrappleControl, Position, PlayerData> Grappler;
 
 class Control : public aunteater::System<GrapitoTimer, GameInputState>
@@ -36,9 +35,7 @@ private:
 
     aunteater::EntityManager & mEntityManager;
     const aunteater::FamilyHelp<CartesianControlled> mCartesianControllables;
-    const aunteater::FamilyHelp<PolarControlled> mPolarControllables;
     const aunteater::FamilyHelp<Grappler> mGrapplers;
-
 };
 
 } // namespace grapito

--- a/src/app/grapkimbo/Utils/Player.h
+++ b/src/app/grapkimbo/Utils/Player.h
@@ -44,5 +44,17 @@ inline bool isThrowing(const PlayerData & aPlayerData)
     return aPlayerData.controlState & ControlState_Throwing;
 }
 
+
+inline bool isAnchored(const PlayerData & aPlayerData)
+{
+    return aPlayerData.mGrappleWeldJoint != nullptr;
+}
+
+
+inline void resetJumps(PlayerData & aPlayerData)
+{
+    aPlayerData.airborneJumpsLeft = player::gAirborneJumps;
+}
+
 } // namespace grapito
 } // namespace ad

--- a/src/app/grapkimbo/Utils/Player.h
+++ b/src/app/grapkimbo/Utils/Player.h
@@ -13,20 +13,35 @@ namespace grapito {
 
 /// \brief This file is working around the absence of a coherent "Player" class.
 
-bool isIdle(const PlayerData & aPlayerData, const AccelAndSpeed & aAccelSpeed)
+
+inline bool isIdle(const PlayerData & aPlayerData, const AccelAndSpeed & aAccelSpeed)
 {
     return (aPlayerData.state & PlayerCollisionState_Grounded)
         && (std::abs(aAccelSpeed.speed.x()) < player::gIdleSpeedLimit);
 }
 
-bool isGoingLeft(const AccelAndSpeed & aAccelSpeed)
+
+inline bool isGoingLeft(const AccelAndSpeed & aAccelSpeed)
 {
     return aAccelSpeed.speed.x() < -player::gIdleSpeedLimit;
 }
 
-bool isGoingRight(const AccelAndSpeed & aAccelSpeed)
+
+inline bool isGoingRight(const AccelAndSpeed & aAccelSpeed)
 {
     return aAccelSpeed.speed.x() > player::gIdleSpeedLimit;
+}
+
+
+inline bool isGrappleOut(const PlayerData & aPlayerData)
+{
+    return aPlayerData.controlState & (ControlState_Attached | ControlState_Throwing);
+}
+
+
+inline bool isThrowing(const PlayerData & aPlayerData)
+{
+    return aPlayerData.controlState & ControlState_Throwing;
 }
 
 } // namespace grapito


### PR DESCRIPTION
close #92

- Add (inifinite) airborne jumps. Implement a grapple tests player utils.
- Limit to a defined number of airborne jumps (currently 1). Reset when landing on ground or successfully grappling.
- Uniformize horizontal axis input read in Control system.
- Simplify control code, prevent ABABAB technique.
