### PR TITLE
topic/grapito#77 handle multiplayer

### DIFF
--- a/src/app/grapkimbo/Context/PlayerList.cpp
+++ b/src/app/grapkimbo/Context/PlayerList.cpp
@@ -57,12 +57,17 @@ int PlayerList::addPlayer(Controller aControllerId, PlayerJoinState aJoinState)
 {
     int availableSlot = getNextSlot();
 
-    if (availableSlot != -1)
+    if (availableSlot != -1
+        && std::ranges::find_if(mPlayerList, [&](const auto & state)
+            {
+                return state.mControllerId == aControllerId;
+            }) == mPlayerList.end())
     {
         mPlayerList.emplace_back(PlayerControllerState{availableSlot, aControllerId, aJoinState});
+        return availableSlot;
     }
 
-    return availableSlot;
+    return -1;
 }
 
 void PlayerList::removePlayer(Controller aControllerId)

--- a/src/app/grapkimbo/Context/PlayerList.cpp
+++ b/src/app/grapkimbo/Context/PlayerList.cpp
@@ -107,5 +107,12 @@ std::vector<Controller> PlayerList::getUnactiveControllers()
     return unactiveControllers;
 }
 
+
+std::size_t PlayerList::countActivePlayers() const
+{
+    return mPlayerList.size();
+}
+
+
 }
 }

--- a/src/app/grapkimbo/Context/PlayerList.h
+++ b/src/app/grapkimbo/Context/PlayerList.h
@@ -19,6 +19,8 @@ struct PlayerControllerState
     int mPlayerSlot;
     Controller mControllerId;
     PlayerJoinState mJoinState;
+    // TODO ability to pick a color
+    math::sdr::Rgb mColor{math::sdr::gCyan};
 };
 
 class PlayerList
@@ -30,7 +32,18 @@ class PlayerList
         PlayerJoinState getPlayerState(Controller aControllerId);
         int addPlayer(Controller aControllerId, PlayerJoinState aJointState);
         void removePlayer(Controller aControllerId);
+        // TODO Clarify what Unactive means here? Actually disconnected controllers,
+        // or controllers connected but not controlling a player?
         std::vector<Controller> getUnactiveControllers();
+
+        std::size_t countActivePlayers() const;
+
+        auto begin() const
+        { return mPlayerList.cbegin(); }
+
+        auto end() const
+        { return mPlayerList.cend(); }
+
     private:
         std::list<PlayerControllerState> mPlayerList;
 };

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -89,7 +89,8 @@ void makeChoosingColorPlayerPlaying(aunteater::weak_entity player)
 
 aunteater::Entity makePlayingPlayer(int aIndex,
                              Controller aController,
-                             math::sdr::Rgb aColor)
+                             math::sdr::Rgb aColor,
+                             Position2 aPosition)
 {
     aunteater::Entity player = aunteater::Entity()
         // The component will be populated by AnimationState system.
@@ -111,7 +112,7 @@ aunteater::Entity makePlayingPlayer(int aIndex,
         .add<Controllable>(aController)
         .add<Mass>(player::gMass)
         .add<PlayerData>(aIndex, aColor)
-        .add<Position>(Position2{3.f, 3.f}, player::gSize) // The position will be set by pendulum simulation
+        .add<Position>(aPosition, player::gSize) // The position will be set by pendulum simulation
         //.add<VisualRectangle>(aColor)
         .add<VisualSprite>((AtlasIndex)aIndex) // the sprite itself is handled by animation system
                                                // SMELL: we hardcode the fact that we use the player id as atlas index

--- a/src/app/grapkimbo/Entities.h
+++ b/src/app/grapkimbo/Entities.h
@@ -30,6 +30,9 @@ aunteater::Entity makeDirectControllable(Controller aController,
 
 aunteater::Entity makeHudText(std::string aMessage, Position2 aScreenPosition, ScreenPosition::Origin aMessageOrigin);
 
+
+// TODO Ad 2022/02/04: Replace sdr::Rgb by a color index, and use it instead of the player index.
+// Will be required to implement choosing color.
 aunteater::Entity makePlayingPlayer(int aIndex,
                              Controller aController,
                              math::sdr::Rgb aColor);

--- a/src/app/grapkimbo/Entities.h
+++ b/src/app/grapkimbo/Entities.h
@@ -18,8 +18,7 @@
 
 
 namespace ad {
-namespace grapito
-{
+namespace grapito {
 
 
 aunteater::Entity makeCamera(Position2 pos = {0.f, 0.f});
@@ -34,8 +33,9 @@ aunteater::Entity makeHudText(std::string aMessage, Position2 aScreenPosition, S
 // TODO Ad 2022/02/04: Replace sdr::Rgb by a color index, and use it instead of the player index.
 // Will be required to implement choosing color.
 aunteater::Entity makePlayingPlayer(int aIndex,
-                             Controller aController,
-                             math::sdr::Rgb aColor);
+                                    Controller aController,
+                                    math::sdr::Rgb aColor,
+                                    Position2 aPosition = {0.f, 3.f});
 
 void kill(aunteater::weak_entity aPlayer);
 

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -59,8 +59,6 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
 {
     mContext->mPlayerList.addPlayer(aController, PlayerJoinState_Playing);
 
-    auto player = setupPlayer(aController);
-
     mSystemManager.add<debug::DirectControl>();
 
     mSystemManager.add<PlayerJoin>(mContext);
@@ -85,7 +83,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
 
     auto renderToScreen = std::make_shared<RenderToScreen>(mEntityManager, mAppInterface, *this); 
     // Done after CameraGuidedControl, to avoid having two camera guides on the frame a player is killed.
-    mSystemManager.add<GameRule>(mContext, std::vector<aunteater::Entity>{player}, controlSystem, renderToScreen);
+    mSystemManager.add<GameRule>(mContext, controlSystem, renderToScreen);
 
     mRenderBackgroundSystem = mSystemManager.add<RenderBackground>(mAppInterface); 
     mRenderBackgroundSystem->addLayer(mContext->pathFor(background::gSpaceImage), background::gSpaceScrollFactor);
@@ -151,6 +149,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
     // Players
     //
     {
+        auto player = setupPlayer(aController);
         mEntityManager.addEntity(player);
 
         // Debug direct control (for camera influence)

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -145,19 +145,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
         createStackFive(mEntityManager, 0.f);
     }
 
-    //
-    // Players
-    //
-    {
-        auto player = setupPlayer(aController);
-        mEntityManager.addEntity(player);
-
-        // Debug direct control (for camera influence)
-        mEntityManager.addEntity(
-            makeDirectControllable(player.get<Controllable>().controller)
-        );
-
-    }
+    // Players are added by GameRule system.
 }
 
 std::pair<TransitionProgress, UpdateStatus> RopeGame::enter(

--- a/src/app/grapkimbo/Systems/GameRule.cpp
+++ b/src/app/grapkimbo/Systems/GameRule.cpp
@@ -140,6 +140,7 @@ class ExpectPlayersPhase : public PhaseBase
     void beforeEnter() override
     {
         mFadeOpacity.reset();
+        mGameRule.resetCompetitors(); // in order to add at least the player that entered the game
         mGameRule.disableGrapples();
         mHudText = getEntityManager().addEntity(makeHudText(mContext->translate(hud_waitplayers_sid), 
                                                             hud::gCountdownPosition,
@@ -209,6 +210,7 @@ class WarmupPhase : public PhaseBase
 
     void updateImpl(float aDelta, StateMachine & aStateMachine)
     {
+        mGameRule.addNewCompetitors();
         mGameRule.setFadeOpacity(mFadeOpacity.advance(aDelta));
         auto param = mCountdownParam.advance(aDelta);
         if(mCountdownParam.isCompleted())
@@ -408,13 +410,21 @@ void GameRule::prepareCameraFadeOut(Position2 aCameraPosition,
 void GameRule::resetCompetitors()
 {
     killAllCompetitors();
+    mAddedCompetitors.clear();
+    addNewCompetitors();
+}
 
+
+void GameRule::addNewCompetitors()
+{
     for (const PlayerControllerState & player : mContext->mPlayerList)
     {
-        if (player.mJoinState == PlayerJoinState_Playing)
+        if (!mAddedCompetitors.contains(player.mPlayerSlot)
+            && player.mJoinState == PlayerJoinState_Playing)
         {
             mEntityManager.addEntity(
                 makePlayingPlayer(player.mPlayerSlot, player.mControllerId, player.mColor));
+            mAddedCompetitors.insert(player.mPlayerSlot);
         }
     }
 }

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -33,6 +33,8 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
         Competition, 
         Congratulation,
         ExpectPlayers,
+        FadeOut,
+        FadeIn,
 
         _End,
     };
@@ -46,6 +48,8 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
     friend class WarmupPhase;
     friend class CompetitionPhase;
     friend class CongratulationPhase;
+    friend class FadeOutPhase;
+    friend class FadeInPhase;
 
 public:
     GameRule(aunteater::EntityManager & aEntityManager,
@@ -59,7 +63,7 @@ private:
     /// \brief Reset all competitors to their initial state.
     void resetCompetitors();
 
-    void addNewCompetitors();
+    void addNewCompetitors(bool aPreserveCameraPosition = false);
 
     /// \brief Remove all competitors from the game.
     void killAllCompetitors(); // Can you tell I watched squid game recently?

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -29,7 +29,6 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
 {
     enum Phase
     {
-        FreeSolo,
         Warmup,
         Competition, 
         Congratulation,
@@ -43,7 +42,6 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
     friend PhasesArray setupGamePhases(std::shared_ptr<Context>, GameRule &);
 
     friend class PhaseBase;
-    friend class FreeSoloPhase;
     friend class ExpectPlayersPhase;
     friend class WarmupPhase;
     friend class CompetitionPhase;
@@ -52,7 +50,6 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
 public:
     GameRule(aunteater::EntityManager & aEntityManager,
              std::shared_ptr<Context> aContext,
-             std::vector<aunteater::Entity> aPlayers,
              std::shared_ptr<Control> aControlSystem,
              std::shared_ptr<RenderToScreen> aRenderToScreenSystem);
 
@@ -85,10 +82,9 @@ private:
     std::shared_ptr<Control> mControlSystem;
     std::shared_ptr<RenderToScreen> mRenderToScreenSystem;
 
-    // TODO remove
-    std::vector<aunteater::Entity> mPlayers;
-
     std::shared_ptr<Context> mContext;
+
+    std::vector<int> mAddedPlayerSlots;
 
     PhasesArray mPhases;
     StateMachine mPhaseMachine;

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -59,6 +59,8 @@ private:
     /// \brief Reset all competitors to their initial state.
     void resetCompetitors();
 
+    void addNewCompetitors();
+
     /// \brief Remove all competitors from the game.
     void killAllCompetitors(); // Can you tell I watched squid game recently?
 
@@ -84,7 +86,8 @@ private:
 
     std::shared_ptr<Context> mContext;
 
-    std::vector<int> mAddedPlayerSlots;
+    // Values from PlayerControllerState.mPlayerSlot
+    std::set<int> mAddedCompetitors;
 
     PhasesArray mPhases;
     StateMachine mPhaseMachine;

--- a/src/app/grapkimbo/Systems/GameRule.h
+++ b/src/app/grapkimbo/Systems/GameRule.h
@@ -33,6 +33,7 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
         Warmup,
         Competition, 
         Congratulation,
+        ExpectPlayers,
 
         _End,
     };
@@ -43,6 +44,7 @@ class GameRule : public aunteater::System<GrapitoTimer, GameInputState>
 
     friend class PhaseBase;
     friend class FreeSoloPhase;
+    friend class ExpectPlayersPhase;
     friend class WarmupPhase;
     friend class CompetitionPhase;
     friend class CongratulationPhase;
@@ -83,7 +85,10 @@ private:
     std::shared_ptr<Control> mControlSystem;
     std::shared_ptr<RenderToScreen> mRenderToScreenSystem;
 
+    // TODO remove
     std::vector<aunteater::Entity> mPlayers;
+
+    std::shared_ptr<Context> mContext;
 
     PhasesArray mPhases;
     StateMachine mPhaseMachine;

--- a/src/app/grapkimbo/Systems/PlayerJoin.cpp
+++ b/src/app/grapkimbo/Systems/PlayerJoin.cpp
@@ -25,14 +25,6 @@ void PlayerJoin::update(const GrapitoTimer aTimer, const GameInputState & aInput
         {
             //Change player to Choosing color state
             int slot = mContext->mPlayerList.addPlayer(controller, PlayerJoinState_Playing);
-            if (slot != -1)
-            {
-                //Add Color choice Menu entity
-                auto player = makePlayingPlayer(slot, controller, math::sdr::gCyan);
-
-                mEntityManager.addEntity(player);
-            }
-
         }
     }
 


### PR DESCRIPTION
closes #77

- Fix: Prevent adding a player if controller is already present.
- Add a phase to wait for at least a second player before starting.
- Clean-up: remove FreeSolo and players list from GameRule.
- Implement ability to join the game during warmup phase.
- Separate fade transitions to their own states.
