### PR TITLE
topic/grapito#71 scoring system

### DIFF
--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -96,6 +96,10 @@ namespace player
     const float gGrappleFriction = 0.5f;
     float gGrappleDistanceJointFactor = 1.3f;
     float gRopeDistanceJointFactor = 1.1f;
+
+    const math::sdr::Rgb gBlueColor{63, 63, 116};
+    const math::sdr::Rgb gGreenColor{52, 212, 136};
+    const math::sdr::Rgb gRedColor{235, 68, 53};
 } // namespace player
 
 

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -160,6 +160,10 @@ namespace player
 
     extern const float gIdleSpeedLimit;
 
+    extern const math::sdr::Rgb gBlueColor;
+    extern const math::sdr::Rgb gGreenColor;
+    extern const math::sdr::Rgb gRedColor;
+
 } // namespace player
 
 

--- a/src/app/grapkimbo/Context/PlayerList.cpp
+++ b/src/app/grapkimbo/Context/PlayerList.cpp
@@ -127,5 +127,11 @@ std::size_t PlayerList::countActivePlayers() const
 }
 
 
+void PlayerList::clear()
+{
+    mPlayerList.clear();
+}
+
+
 }
 }

--- a/src/app/grapkimbo/Context/PlayerList.cpp
+++ b/src/app/grapkimbo/Context/PlayerList.cpp
@@ -53,6 +53,14 @@ PlayerJoinState PlayerList::getPlayerState(Controller aControllerId)
     return PlayerJoinState_NotActive;
 }
 
+
+const std::array<math::sdr::Rgb, 3> gPlayerIdToColor{
+    player::gBlueColor,
+    player::gGreenColor,
+    player::gRedColor,
+};
+
+
 int PlayerList::addPlayer(Controller aControllerId, PlayerJoinState aJoinState)
 {
     int availableSlot = getNextSlot();
@@ -63,7 +71,12 @@ int PlayerList::addPlayer(Controller aControllerId, PlayerJoinState aJoinState)
                 return state.mControllerId == aControllerId;
             }) == mPlayerList.end())
     {
-        mPlayerList.emplace_back(PlayerControllerState{availableSlot, aControllerId, aJoinState});
+        mPlayerList.emplace_back(PlayerControllerState{
+            availableSlot,
+            aControllerId,
+            aJoinState,
+            gPlayerIdToColor.at(availableSlot),
+        });
         return availableSlot;
     }
 

--- a/src/app/grapkimbo/Context/PlayerList.h
+++ b/src/app/grapkimbo/Context/PlayerList.h
@@ -7,7 +7,8 @@ namespace grapito {
 
 enum PlayerJoinState
 {
-    PlayerJoinState_ChoosingColor,
+    PlayerJoinState_ChoosingColor, // Actually, this feels coupled to specific knowledge of the game.
+                                   // Maybe this file should remain more abstract than that.
     PlayerJoinState_Queued, // Waiting to enter the next game
     PlayerJoinState_Playing,
 
@@ -33,8 +34,8 @@ class PlayerList
         PlayerJoinState getPlayerState(Controller aControllerId);
         int addPlayer(Controller aControllerId, PlayerJoinState aJointState);
         void removePlayer(Controller aControllerId);
-        // TODO Clarify what Unactive means here? Actually disconnected controllers,
-        // or controllers connected but not controlling a player?
+        /// \brief All controllers for which a player has not been associated (i.e. start has not been pressed).
+        /// Whether the controller is connected to the system or not.
         std::vector<Controller> getUnactiveControllers();
 
         std::size_t countActivePlayers() const;

--- a/src/app/grapkimbo/Context/PlayerList.h
+++ b/src/app/grapkimbo/Context/PlayerList.h
@@ -40,6 +40,8 @@ class PlayerList
 
         std::size_t countActivePlayers() const;
 
+        void clear();
+
         auto begin()
         { return mPlayerList.begin(); }
 

--- a/src/app/grapkimbo/Context/PlayerList.h
+++ b/src/app/grapkimbo/Context/PlayerList.h
@@ -22,7 +22,7 @@ struct PlayerControllerState
     Controller mControllerId;
     PlayerJoinState mJoinState;
     // TODO ability to pick a color
-    math::sdr::Rgb mColor{math::sdr::gCyan};
+    math::sdr::Rgb mColor;
 };
 
 class PlayerList

--- a/src/app/grapkimbo/Input.cpp
+++ b/src/app/grapkimbo/Input.cpp
@@ -135,6 +135,20 @@ bool isGamepadPresent(Controller aController)
 }
 
 
+std::vector<Controller> listPresentGamepads()
+{
+    std::vector<Controller> present;
+    for (const Controller controller : gAllControllers)
+    {
+        if(isGamepad(controller) && isGamepadPresent(controller))
+        {
+            present.push_back(controller);
+        }
+    }
+    return present;
+}
+
+
 GameInputState::GameInputState()
 {
     for (const Controller controller : gAllControllers)

--- a/src/app/grapkimbo/Input.h
+++ b/src/app/grapkimbo/Input.h
@@ -163,6 +163,8 @@ constexpr bool isGamepad(Controller aController);
 
 bool isGamepadPresent(Controller aController);
 
+std::vector<Controller> listPresentGamepads();
+
 enum class AxisSign
 {
     Positive,

--- a/src/app/grapkimbo/Scenery/GameScene.cpp
+++ b/src/app/grapkimbo/Scenery/GameScene.cpp
@@ -20,6 +20,13 @@ GameScene::GameScene(std::shared_ptr<Context> aContext,
 {}
 
 
+GameScene::~GameScene()
+{
+    // All players added during the game should be cleared, for next game.
+    mContext->mPlayerList.clear();
+}
+
+
 UpdateStatus GameScene::update(
     const GrapitoTimer & aTimer,
     const GameInputState & aInputs,

--- a/src/app/grapkimbo/Scenery/GameScene.h
+++ b/src/app/grapkimbo/Scenery/GameScene.h
@@ -24,6 +24,8 @@ public:
     GameScene(std::shared_ptr<Context> aContext,
               std::shared_ptr<graphics::AppInterface> aAppInterface);
 
+    ~GameScene();
+
     /// \brief Complete update step, including rendering.
     UpdateStatus update(
         const GrapitoTimer & aTimer,

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -63,7 +63,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
     GameScene{std::move(aContext), std::move(aAppInterface)},
     mGameMode{aGameMode}
 {
-    mContext->mPlayerList.addPlayer(aController, PlayerJoinState_Playing);
+    mContext->mPlayerList.addPlayer(aController, PlayerJoinState_Queued);
 
     mSystemManager.add<debug::DirectControl>();
 

--- a/src/app/grapkimbo/Systems/Rules/CompetitionRule.cpp
+++ b/src/app/grapkimbo/Systems/Rules/CompetitionRule.cpp
@@ -33,7 +33,6 @@ const StringId hud_pressstart_sid = handy::internalizeString("hud_pressstart");
 const StringId hud_joining_sid = handy::internalizeString("hud_joining");
 
 
-
 using PhaseParent = PhaseBase<CompetitionRule>;
 
 
@@ -329,12 +328,7 @@ CompetitionRule::CompetitionRule(aunteater::EntityManager & aEntityManager,
     mPhases{setupGamePhases(mContext, *this)},
     // ATTENTION the state machine is entering the first state directly, before CompetitionRule is done cting.
     mPhaseMachine{mPhases[ExpectPlayers]}
-{
-    // Initially, the competitor who entered the game will be in PlayerList with _Playing state.
-    // Create a PlayerStatus for them, and ensure they are queued to be instantiated into the game.
-    updateConnectedControllers();
-    updatePlayerQueue(PlayerJoinState_Playing);
-}
+{}
 
 
 void CompetitionRule::update(const GrapitoTimer aTimer, const GameInputState & aInput)
@@ -452,11 +446,11 @@ void CompetitionRule::updateConnectedControllers()
 }
 
 
-void CompetitionRule::updatePlayerQueue(PlayerJoinState aStateToQueueFrom)
+void CompetitionRule::updatePlayerQueue()
 {
     for (PlayerControllerState & player : mContext->mPlayerList)
     {
-        if (player.mJoinState == aStateToQueueFrom)
+        if (player.mJoinState == PlayerJoinState_Queued)
         {
             mControllerToPlayerStatus.at(player.mControllerId).status = PlayerStatus::Queued;
         }

--- a/src/app/grapkimbo/Systems/Rules/CompetitionRule.cpp
+++ b/src/app/grapkimbo/Systems/Rules/CompetitionRule.cpp
@@ -36,7 +36,20 @@ const StringId hud_joining_sid = handy::internalizeString("hud_joining");
 
 using PhaseParent = PhaseBase<CompetitionRule>;
 
-using CongratulationPhase = MessagePhase<CompetitionRule>;
+
+class CongratulationPhase : public MessagePhase<CompetitionRule>
+{
+    using Base_type = MessagePhase<CompetitionRule>;
+public:
+    using Base_type::Base_type;
+
+    void beforeEnter() override
+    {
+        Base_type::beforeEnter();
+        mRule.incrementScore();
+    }
+};
+
 
 class ExpectPlayersPhase : public PhaseParent
 {
@@ -369,6 +382,18 @@ std::size_t CompetitionRule::eliminateCompetitors()
     }
 
     return remainingCompetitors;
+}
+
+
+void CompetitionRule::incrementScore()
+{
+    for(auto & [controller, playerStatus] : mControllerToPlayerStatus)
+    {
+        if (playerStatus.status == PlayerStatus::Playing)
+        {
+            ++playerStatus.score;
+        }
+    }
 }
 
 

--- a/src/app/grapkimbo/Systems/Rules/CompetitionRule.cpp
+++ b/src/app/grapkimbo/Systems/Rules/CompetitionRule.cpp
@@ -462,6 +462,8 @@ void CompetitionRule::instantiateQueuedCompetitors(bool aPreserveCameraPosition)
 {
     for (PlayerControllerState & player : mContext->mPlayerList)
     {
+        auto & playerStatus = mControllerToPlayerStatus.at(player.mControllerId);
+
         // Note we do not keep the context player state in sync with the local player status
         // In particular, we do not move the context back to queued, ever.
         if (player.mJoinState == PlayerJoinState_Queued)
@@ -469,9 +471,9 @@ void CompetitionRule::instantiateQueuedCompetitors(bool aPreserveCameraPosition)
             // Advance queued context players to playing state, which is used to control pause menu for e.g.
             // This is feedback from downstream to the context, which is maybe not good architecture.
             player.mJoinState = PlayerJoinState_Playing;
+            mHudLine.setColor(playerStatus, player.mColor);
         }
 
-        auto & playerStatus = mControllerToPlayerStatus.at(player.mControllerId);
         if (playerStatus.status == PlayerStatus::Queued || playerStatus.status == PlayerStatus::Eliminated)
         {
             playerStatus.status = PlayerStatus::Playing;
@@ -543,6 +545,10 @@ PlayerHud::PlayerHud(PlayerStatus & aStatus, aunteater::EntityManager & aEntityM
     hudText->get<Text>().size = Text::Small;
 }
 
+void PlayerHud::setColor(math::sdr::Rgb aColor)
+{
+    hudText->get<Text>().color = aColor;
+}
 
 void PlayerHud::update()
 {
@@ -556,6 +562,17 @@ void HudLine::add(PlayerStatus & aStatus)
     reflow();
 }
 
+void HudLine::setColor(PlayerStatus & aStatus, math::sdr::Rgb aColor)
+{
+    for (auto & hud : mHuds)
+    {
+        if(&hud.status == &aStatus)
+        {
+            hud.setColor(aColor);
+            break;
+        }
+    }
+}
 
 void HudLine::reflow()
 {

--- a/src/app/grapkimbo/Systems/Rules/CompetitionRule.h
+++ b/src/app/grapkimbo/Systems/Rules/CompetitionRule.h
@@ -158,7 +158,7 @@ public:
 private:
     void updateConnectedControllers();
 
-    void updatePlayerQueue(PlayerJoinState aStateToQueueFrom = PlayerJoinState_Queued);
+    void updatePlayerQueue();
 
     /// \brief Reset all competitors to their initial state.
     void resetCompetitors();

--- a/src/app/grapkimbo/Systems/Rules/CompetitionRule.h
+++ b/src/app/grapkimbo/Systems/Rules/CompetitionRule.h
@@ -140,6 +140,7 @@ class CompetitionRule : public RuleBase
     friend class PhaseBase;
     template <class>
     friend class MessagePhase;
+    friend class CongratulationPhase;
     friend class ExpectPlayersPhase;
     friend class WarmupPhase;
     friend class CompetitionPhase;
@@ -173,6 +174,8 @@ private:
     /// \brief Apply the elimination rule to each competitor, removing competitors failing the test.
     /// \return The number of competitors remaining in the game after this step of eliminations.
     std::size_t eliminateCompetitors();
+
+    void incrementScore();
 
     aunteater::Entity prepareCameraFadeOut(Position2 aCameraPosition,
                                            const Position & aGeometry,

--- a/src/app/grapkimbo/Systems/Rules/CompetitionRule.h
+++ b/src/app/grapkimbo/Systems/Rules/CompetitionRule.h
@@ -79,14 +79,9 @@ struct PlayerStatus
 
 struct PlayerHud
 {
-    //PlayerHud(math::sdr::Rgb aColor, aunteater::EntityManager & aEntityManager) :
-    //    mHudText{aEntityManager.addEntity(
-    //        makeHudText("", hud::gAltimeterPosition, ScreenPosition::Center))},
-    //{
-    //    mHudText->get<Text>().color = aColor;
-    //}
-
     PlayerHud(PlayerStatus & aStatus, aunteater::EntityManager & aEntityManager);
+
+    void setColor(math::sdr::Rgb aColor);
 
     void update();
 
@@ -103,6 +98,8 @@ public:
     {}
 
     void add(PlayerStatus & aStatus);
+
+    void setColor(PlayerStatus & aStatus, math::sdr::Rgb aColor);
 
     void update()
     {

--- a/src/app/grapkimbo/Systems/Rules/FloorIsLavaRule.cpp
+++ b/src/app/grapkimbo/Systems/Rules/FloorIsLavaRule.cpp
@@ -275,7 +275,8 @@ void FloorIsLavaRule::update(const GrapitoTimer aTimer, const GameInputState & a
 
 void FloorIsLavaRule::addPlayer()
 {
-    PlayerControllerState player = *mContext->mPlayerList.begin();
+    PlayerControllerState & player = *mContext->mPlayerList.begin();
+    player.mJoinState = PlayerJoinState_Playing;
     mPlayer = mEntityManager.addEntity(
         makePlayingPlayer(player.mPlayerSlot, player.mControllerId, player.mColor, {0.f, 3.f}));
 }

--- a/src/app/grapkimbo/Systems/Rules/FreesoloRule.cpp
+++ b/src/app/grapkimbo/Systems/Rules/FreesoloRule.cpp
@@ -26,7 +26,8 @@ FreesoloRule::FreesoloRule(aunteater::EntityManager & aEntityManager,
 {
     mHudText->get<Text>().size = Text::Small;
 
-    PlayerControllerState player = *mContext->mPlayerList.begin();
+    PlayerControllerState & player = *mContext->mPlayerList.begin();
+    player.mJoinState = PlayerJoinState_Playing;
     mPlayer = mEntityManager.addEntity(
         makePlayingPlayer(player.mPlayerSlot, player.mControllerId, player.mColor, {0.f, 3.f}));
 }

--- a/src/app/grapkimbo/Systems/Rules/Phases.h
+++ b/src/app/grapkimbo/Systems/Rules/Phases.h
@@ -59,6 +59,7 @@ class MessagePhase : public PhaseBase<T_rule>
         return result;
     }
 
+
 public:
     MessagePhase(std::shared_ptr<Context> aContext, T_rule & aCompetitionRule,
                  std::string aMessage, T_rule::Phase aNextPhase) :
@@ -69,11 +70,6 @@ public:
         mHudPositionInterpolation{mHudPositionInterpolationReference}
     {}
 
-private:
-    void resetInterpolation()
-    {
-        mHudPositionInterpolation = mHudPositionInterpolationReference;
-    }
 
     void beforeEnter() override
     {
@@ -102,13 +98,18 @@ private:
         return UpdateStatus::SwapBuffers;
     }
 
-
     void beforeExit() override
     {
         // TODO delay delete ?
         mHudText->markToRemove();
     }
 
+
+private:
+    void resetInterpolation()
+    {
+        mHudPositionInterpolation = mHudPositionInterpolationReference;
+    }
 
     std::string mMessage; 
     T_rule::Phase mNextPhase;


### PR DESCRIPTION
closes #71
closes #134

- Implement a hud line for players, showing current status.
- Keep scores.
- Change RopeGame initial player state to queued.
- Use the corresponding player color for status line entries.
- Fix bug when multiplayer was launched a second time.
