### PR TITLE
topic/grapito#136 jump and walling animations

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -30,7 +30,7 @@ class GrapitoConan(ConanFile):
         ("vorbis/1.3.7"),
 
         ("aunteater/50a0c94674@adnn/develop"),
-        ("graphics/43d7c2d95e@adnn/develop"),
+        ("graphics/6cb63a5c01@adnn/develop"),
         ("math/fd9b30cce0@adnn/develop"),
         ("sounds/ad53c2d701@adnn/develop"),
         ("websocket/ef5d5bf4d9@adnn/develop"),

--- a/src/app/grapkimbo/Animation/PlayerAnimation.h
+++ b/src/app/grapkimbo/Animation/PlayerAnimation.h
@@ -12,10 +12,12 @@ enum class PlayerAnimation
     IdleRight,
     RunLeft,
     RunRight,
+    JumpLeft,
+    JumpRight,
 
-    // Keep me last
-    _Count,
-};
+    // Keep it last
+    _Count/*
+*/};
 
 
 } // namespace grapito

--- a/src/app/grapkimbo/Animation/PlayerAnimation.h
+++ b/src/app/grapkimbo/Animation/PlayerAnimation.h
@@ -14,6 +14,8 @@ enum class PlayerAnimation
     RunRight,
     JumpLeft,
     JumpRight,
+    WalledLeft,
+    WalledRight,
 
     // Keep it last
     _Count/*

--- a/src/app/grapkimbo/Components/AnimatedSprite.h
+++ b/src/app/grapkimbo/Components/AnimatedSprite.h
@@ -19,13 +19,13 @@ struct AnimatedSprite : public aunteater::Component<AnimatedSprite>
     AnimatedSprite() = default;
 
     template <class T_parameterAnimation>
-    AnimatedSprite(StringId aAnimation, T_parameterAnimation aParameterAnimation, bool aHorizontalMirroring = false) :
+    AnimatedSprite(StringId aAnimation, T_parameterAnimation aParameterAnimation, bool aHorizontalFlipping = false) :
         animation{aAnimation},
         parameter{[paramAnimation = std::move(aParameterAnimation)](float aDelta) mutable
             {
                 return paramAnimation.advance(aDelta);
             }},
-        horizontalMirroring{aHorizontalMirroring}
+        horizontalFlipping{aHorizontalFlipping}
     {}
 
     float advance(float aDelta)
@@ -35,7 +35,7 @@ struct AnimatedSprite : public aunteater::Component<AnimatedSprite>
 
     StringId animation = StringId::Null();  
     float parameterAdvanceSpeed{1.f};
-    bool horizontalMirroring{false};
+    bool horizontalFlipping{false};
 private:
     // This provides type erasure for the parameter animation
     std::function<float(float)> parameter;

--- a/src/app/grapkimbo/Components/Body.h
+++ b/src/app/grapkimbo/Components/Body.h
@@ -154,7 +154,7 @@ struct Body : public aunteater::Component<Body>
     float friction;
     float restitution;
 
-    math::Radian<float> theta;
+    Radian theta;
 
     Shape shape;
 

--- a/src/app/grapkimbo/Components/VisualSprite.h
+++ b/src/app/grapkimbo/Components/VisualSprite.h
@@ -6,6 +6,7 @@
 #include <aunteater/Component.h>
 
 #include <graphics/Sprite.h>
+#include <graphics/SpriteLoading.h>
 
 
 namespace ad {
@@ -23,6 +24,12 @@ struct VisualSprite : public aunteater::Component<VisualSprite>
     VisualSprite(AtlasIndex aAtlas = 0) :
         atlas{aAtlas},
         sprite{ {0, 0}, {0, 0} }
+    {}
+
+
+    VisualSprite(AtlasIndex aAtlas, graphics::LoadedSprite aSprite) :
+        atlas{aAtlas},
+        sprite{aSprite}
     {}
 
     Size2 getWorldSize() const

--- a/src/app/grapkimbo/Components/VisualSprite.h
+++ b/src/app/grapkimbo/Components/VisualSprite.h
@@ -5,6 +5,7 @@
 
 #include <aunteater/Component.h>
 
+#include <graphics/commons.h>
 #include <graphics/Sprite.h>
 #include <graphics/SpriteLoading.h>
 
@@ -39,7 +40,7 @@ struct VisualSprite : public aunteater::Component<VisualSprite>
 
     AtlasIndex atlas;
     graphics::LoadedSprite sprite;
-    math::Vec<2, int> mirroring{1, 1};
+    graphics::Mirroring mirroring{graphics::Mirroring::None};
     Alignment alignment{AlignRight};
 };
 

--- a/src/app/grapkimbo/Components/VisualSprite.h
+++ b/src/app/grapkimbo/Components/VisualSprite.h
@@ -1,6 +1,8 @@
 #pragma once
 
 
+#include "../Configuration.h"
+
 #include <aunteater/Component.h>
 
 #include <graphics/Sprite.h>
@@ -12,14 +14,26 @@ namespace grapito {
 
 struct VisualSprite : public aunteater::Component<VisualSprite>
 {
+    enum Alignment
+    {
+        AlignLeft,
+        AlignRight,
+    };
+
     VisualSprite(AtlasIndex aAtlas = 0) :
         atlas{aAtlas},
         sprite{ {0, 0}, {0, 0} }
     {}
 
+    Size2 getWorldSize() const
+    {
+        return render::gSpritePixelWorldSize * static_cast<Size2>(sprite.dimension());
+    }
+
     AtlasIndex atlas;
     graphics::LoadedSprite sprite;
     math::Vec<2, int> mirroring{1, 1};
+    Alignment alignment{AlignRight};
 };
 
 

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -93,6 +93,7 @@ namespace player
     const float gDetachSpeedBoostFactor = 1.5f;
     const float gIdleSpeedLimit = 1;
     const math::Size<2, float> gSize = math::Size<2, float>{5.6f, 7.5f} / gGigantismDampeningFactor;
+    const math::Size<2, float> gGrappleSpritePixelSize{30.f, 30.f};
     const float gGrappleFriction = 0.5f;
     float gGrappleDistanceJointFactor = 1.3f;
     float gRopeDistanceJointFactor = 1.1f;

--- a/src/app/grapkimbo/Configuration.cpp
+++ b/src/app/grapkimbo/Configuration.cpp
@@ -112,6 +112,12 @@ namespace render
 } // namespace render
 
 
+namespace rope
+{
+    const math::hdr::Rgba gColor{0.76f, 0.55f, 0.43f};
+} // namespace rope
+
+
 namespace spriteanimation
 {
     // The ASE animations are expressed in milliseconds

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -132,6 +132,7 @@ namespace player
     extern const float gDetachSpeedBoostFactor;
     constexpr float gMass = 80.f;
     extern const math::Size<2, float> gSize;
+    extern const math::Size<2, float> gGrappleSpritePixelSize;
     constexpr float gInitialRopeLength = 3.f;
     constexpr math::Radian<float> gInitialAngle{math::pi<float>/3.f};
     //TODO(franz) move to impl file

--- a/src/app/grapkimbo/Configuration.h
+++ b/src/app/grapkimbo/Configuration.h
@@ -186,6 +186,7 @@ namespace rope
     constexpr GLfloat ropeWidth = .2f;
     constexpr GLfloat ropeHalfwidth = ropeWidth / 2 ;
     constexpr GLfloat curveTension = 0.f; // I.e. Catmull Rom
+    extern const math::hdr::Rgba gColor;
 }
 
 

--- a/src/app/grapkimbo/Context/Context.h
+++ b/src/app/grapkimbo/Context/Context.h
@@ -23,6 +23,7 @@ struct Context
     filesystem::path pathFor(const filesystem::path &aAsset) const;
 
     const arte::AnimationSpriteSheet & loadAnimationSpriteSheet(const filesystem::path &aAsset);
+    const graphics::sprite::SingleLoad & loadSingleSprite(const filesystem::path &aAsset);
     const OggSoundData & loadOggSoundData(const filesystem::path &aAsset, bool streamed);
 
     Resources resources;
@@ -58,6 +59,13 @@ inline const arte::AnimationSpriteSheet & Context::loadAnimationSpriteSheet(cons
 {
     return resources.animationSpriteSheets.load(aAsset, resources.locator); 
 }
+
+
+inline const graphics::sprite::SingleLoad & Context::loadSingleSprite(const filesystem::path &aAsset)
+{
+    return resources.singleSprites.load(aAsset, resources.locator); 
+}
+
 
 inline const OggSoundData & Context::loadOggSoundData(const filesystem::path &aAsset, bool streamed)
 {

--- a/src/app/grapkimbo/Context/Resources.h
+++ b/src/app/grapkimbo/Context/Resources.h
@@ -5,6 +5,8 @@
 #include "sounds/SoundManager.h"
 #include <arte/SpriteSheet.h>
 
+#include <graphics/SpriteLoading.h>
+
 #include <resource/ResourceLocator.h>
 #include <resource/ResourceManager.h>
 
@@ -18,6 +20,11 @@ struct Resources
     resource::ResourceLocator locator;
     resource::ResourceManager<arte::AnimationSpriteSheet, 
                               &arte::AnimationSpriteSheet::LoadAseFile> animationSpriteSheets{};
+    resource::ResourceManager<graphics::sprite::SingleLoad, 
+                              [](const filesystem::path & aImagePath) -> graphics::sprite::SingleLoad
+                                {
+                                    return graphics::sprite::load(arte::ImageRgba{aImagePath});
+                                }> singleSprites{};
     resource::ResourceManager<OggSoundData,
                               sounds::loadOggFileFromPath> oggSoundFiles{};
 };

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -223,7 +223,7 @@ void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEn
     aPlayer->get<PlayerData>().grapple = aEntityManager.addEntity(aunteater::Entity()
             .add<Position>(
                 grapplePos,
-                math::Size<2, float>{1.f, 1.f}
+                math::Size<2, float>{player::gGrappleSpritePixelSize * render::gSpritePixelWorldSize}
                 )
             // TODO (Franz): named "configuration" instead of magic numbers.
             .add<Body>(
@@ -238,6 +238,7 @@ void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEn
                 std::vector<CollisionType>{CollisionType_Static_Env},
                 std::vector<CollisionType>{CollisionType_Static_Env, CollisionType_Moving_Env}
                 )
+            //.add<VisualPolygon>(rope::grappleVertices, math::sdr::gYellow)
             .add<VisualSprite>(gGrappleAtlasIndex,
                                aContext.loadSingleSprite("sprite_sheet/grapple.png").second)
             .add<AccelAndSpeed>(grappleImpulse, 0.f)

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -209,7 +209,7 @@ aunteater::Entity createRopeSegment(Position2 origin, Position2 end, aunteater::
                 size
                 )
             .add<RopeSegment>(aPlayer->get<PlayerData>().id)
-            .add<VisualRectangle>(math::sdr::gGreen, VisualRectangle::Scope::RopeStructure)
+            //.add<VisualRectangle>(math::sdr::gGreen, VisualRectangle::Scope::RopeStructure)
     ;
 
     setLocalPointToWorldPos(rope, {0.f, rope::ropeHalfwidth}, origin);

--- a/src/app/grapkimbo/Entities.cpp
+++ b/src/app/grapkimbo/Entities.cpp
@@ -24,6 +24,8 @@
 
 #include "Components/Debug/DirectControlTag.h"
 
+#include "Context/Context.h"
+
 #include "Utils/Grapple.h"
 #include "Utils/PhysicsStructs.h"
 
@@ -214,7 +216,7 @@ aunteater::Entity createRopeSegment(Position2 origin, Position2 end, aunteater::
     return rope;
 }
 
-void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager)
+void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager, Context & aContext)
 {
     Position2 grapplePos = static_cast<Position2>(aPlayer->get<Position>().position.as<math::Vec>() + aPlayer->get<Body>().massCenter.as<math::Vec>() + Vec2{.5f, .5f});
     Vec2 grappleImpulse = aPlayer->get<PlayerData>().mAimVector * player::gGrappleBaseImpulse + aPlayer->get<AccelAndSpeed>().speed;
@@ -236,7 +238,8 @@ void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEn
                 std::vector<CollisionType>{CollisionType_Static_Env},
                 std::vector<CollisionType>{CollisionType_Static_Env, CollisionType_Moving_Env}
                 )
-            .add<VisualPolygon>(rope::grappleVertices, math::sdr::gYellow)
+            .add<VisualSprite>(gGrappleAtlasIndex,
+                               aContext.loadSingleSprite("sprite_sheet/grapple.png").second)
             .add<AccelAndSpeed>(grappleImpulse, 0.f)
             );
 

--- a/src/app/grapkimbo/Entities.h
+++ b/src/app/grapkimbo/Entities.h
@@ -21,6 +21,10 @@ namespace ad {
 namespace grapito {
 
 
+// TODO Ad 2022/02/10: Refactor this major SMELL.
+//  We rely on some global mutable state to pass the atlas id accross to throwGrapple().
+inline std::size_t gGrappleAtlasIndex;
+
 aunteater::Entity makeCamera(Position2 pos = {0.f, 0.f});
 
 aunteater::Entity makeDirectControllable(Controller aController,
@@ -45,7 +49,7 @@ aunteater::Entity makeAnchor(Position2 aPosition, std::vector<Position2> aVertic
 
 aunteater::Entity createRopeSegment(Position2 origin, Position2 end, aunteater::weak_entity aPlayer);
 
-void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager);
+void throwGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager, Context & aContext);
 
 void attachPlayerToGrapple(aunteater::weak_entity aPlayer, aunteater::EntityManager & aEntityManager);
 

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -120,6 +120,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
         auto spriteSheets = {
             std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/idle.json")),
             std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/run.json")),
+            std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/jump.json")),
         };
 
         graphics::sprite::Animator animator;
@@ -136,6 +137,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
                 std::vector<arte::ImageRgba>{
                     arte::ImageRgba{mContext->pathFor("sprite_sheet/idle_" + color + ".png")},
                     arte::ImageRgba{mContext->pathFor("sprite_sheet/run_" + color + ".png")},
+                    arte::ImageRgba{mContext->pathFor("sprite_sheet/jump_" + color + ".png")},
                 });
             mRenderWorldSystem->installAtlas(graphics::sprite::loadAtlas(colorVariation));
         }

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -121,6 +121,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
             std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/idle.json")),
             std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/run.json")),
             std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/jump.json")),
+            std::ref(mContext->loadAnimationSpriteSheet("sprite_sheet/walled.json")),
         };
 
         graphics::sprite::Animator animator;
@@ -138,6 +139,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
                     arte::ImageRgba{mContext->pathFor("sprite_sheet/idle_" + color + ".png")},
                     arte::ImageRgba{mContext->pathFor("sprite_sheet/run_" + color + ".png")},
                     arte::ImageRgba{mContext->pathFor("sprite_sheet/jump_" + color + ".png")},
+                    arte::ImageRgba{mContext->pathFor("sprite_sheet/walled_" + color + ".png")},
                 });
             mRenderWorldSystem->installAtlas(graphics::sprite::loadAtlas(colorVariation));
         }

--- a/src/app/grapkimbo/Scenery/RopeGame.cpp
+++ b/src/app/grapkimbo/Scenery/RopeGame.cpp
@@ -68,7 +68,7 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
     mSystemManager.add<debug::DirectControl>();
 
     mSystemManager.add<PlayerJoin>(mContext);
-    std::shared_ptr<Control> controlSystem = mSystemManager.add<Control>();
+    std::shared_ptr<Control> controlSystem = mSystemManager.add<Control>(mContext);
     mSystemManager.add<Gravity>();
     mSystemManager.add<RopeCreation>();
 
@@ -144,6 +144,13 @@ RopeGame::RopeGame(std::shared_ptr<Context> aContext,
             mRenderWorldSystem->installAtlas(graphics::sprite::loadAtlas(colorVariation));
         }
     }
+
+    { // Load grapple sprite
+        const graphics::sprite::LoadedAtlas & atlas = mContext->loadSingleSprite("sprite_sheet/grapple.png").first;
+        // TODO Ad 2022/02/10: Refactor this major SMELL.
+        gGrappleAtlasIndex = mRenderWorldSystem->installAtlas(atlas);
+    }
+
 
     { // Load sounds
         mContext->loadOggSoundData("sounds/burn.ogg", false);

--- a/src/app/grapkimbo/Systems/Control.cpp
+++ b/src/app/grapkimbo/Systems/Control.cpp
@@ -29,8 +29,9 @@ namespace grapito
 const StringId soundId_JumpSid = handy::internalizeString("jump");
 const StringId soundId_RopeJumpSid = handy::internalizeString("ropejump");
 
-Control::Control(aunteater::EntityManager & aEntityManager) :
+Control::Control(aunteater::EntityManager & aEntityManager, std::shared_ptr<Context> aContext) :
     mEntityManager{aEntityManager},
+    mContext{std::move(aContext)},
     mCartesianControllables{mEntityManager},
     mGrapplers{mEntityManager}
 {}
@@ -250,7 +251,7 @@ void Control::update(const GrapitoTimer, const GameInputState & aInputState)
 
         if (mGrapplingEnabled && inputs[Grapple].positiveEdge() && !isGrappleOut(playerData))
         {
-            throwGrapple(player, mEntityManager);
+            throwGrapple(player, mEntityManager, *mContext);
             playerData.controlState |= ControlState_Throwing;
         }
 

--- a/src/app/grapkimbo/Systems/Control.h
+++ b/src/app/grapkimbo/Systems/Control.h
@@ -25,7 +25,7 @@ class Control : public aunteater::System<GrapitoTimer, GameInputState>
 {
 
 public:
-    Control(aunteater::EntityManager & aEntityManager);
+    Control(aunteater::EntityManager & aEntityManager, std::shared_ptr<Context> aContext);
 
     void update(const GrapitoTimer, const GameInputState & aInputState) override;
 
@@ -36,6 +36,7 @@ private:
     std::pair<Position2, double> anchor(const Position2 aPosition);
 
     aunteater::EntityManager & mEntityManager;
+    std::shared_ptr<Context> mContext;
     const aunteater::FamilyHelp<CartesianControlled> mCartesianControllables;
     const aunteater::FamilyHelp<Grappler> mGrapplers;
 

--- a/src/app/grapkimbo/Systems/PlayerJoin.cpp
+++ b/src/app/grapkimbo/Systems/PlayerJoin.cpp
@@ -1,6 +1,7 @@
 #include "PlayerJoin.h"
 
 #include "../Configuration.h"
+#include "../Logging.h"
 #include "../Timer.h"
 #include "Entities.h"
 #include "commons.h"
@@ -34,6 +35,7 @@ void PlayerJoin::update(const GrapitoTimer aTimer, const GameInputState & aInput
 
         if (!(controllable.controller == Controller::KeyboardMouse) && !isGamepadPresent(controllable.controller))
         {
+            ADLOG(info)("Removing player {} from the list.", player->get<PlayerData>().id);
             mContext->mPlayerList.removePlayer(controllable.controller);
             mEntityManager.markToRemove(player);
         }

--- a/src/app/grapkimbo/Systems/RenderWorld.cpp
+++ b/src/app/grapkimbo/Systems/RenderWorld.cpp
@@ -137,11 +137,24 @@ void RenderWorld::update(const GrapitoTimer aTimer, const GameInputState &)
 
     { // Sprites
         std::ranges::for_each(mAtlasToSprites, [](auto & aSprites){aSprites.clear();});
-        for(const auto & [position, visualSprite] : mSprites)
+        for(const auto & [geometry, visualSprite] : mSprites)
         {
+            Position2 position = [&]()
+            {
+                if (visualSprite.alignment == VisualSprite::AlignLeft)
+                {
+                    return geometry.position;
+                }
+                else
+                {
+                    return geometry.position 
+                        + Vec2{geometry.dimension.width() - visualSprite.getWorldSize().width(), 0.f};
+                }
+            }();
+
             mAtlasToSprites
                 .at(visualSprite.atlas)
-                    .emplace_back(position.position,
+                    .emplace_back(position,
                                   visualSprite.sprite,
                                   render::gSpriteOpacity,
                                   visualSprite.mirroring);

--- a/src/app/grapkimbo/Systems/RenderWorld.cpp
+++ b/src/app/grapkimbo/Systems/RenderWorld.cpp
@@ -35,7 +35,9 @@ RenderWorld::RenderWorld(aunteater::EntityManager & aEntityManager,
     mTrivialPolygon{aAppInterface->getWindowSize()},
     mCurving{render::gBezierSubdivisions},
     mSpriting{render::gSpritePixelWorldSize}
-{}
+{
+    mCurving.setColor(rope::gColor);
+}
 
 
 AtlasIndex RenderWorld::installAtlas(graphics::sprite::LoadedAtlas aAtlas)

--- a/src/app/grapkimbo/Systems/RenderWorld.cpp
+++ b/src/app/grapkimbo/Systems/RenderWorld.cpp
@@ -137,8 +137,9 @@ void RenderWorld::update(const GrapitoTimer aTimer, const GameInputState &)
 
     { // Sprites
         std::ranges::for_each(mAtlasToSprites, [](auto & aSprites){aSprites.clear();});
-        for(const auto & [geometry, visualSprite] : mSprites)
+        for(const auto & [body, geometry, visualSprite] : mSprites)
         {
+            // Handle sprite alignment on the bouding box edges.
             Position2 position = [&]()
             {
                 if (visualSprite.alignment == VisualSprite::AlignLeft)
@@ -152,12 +153,28 @@ void RenderWorld::update(const GrapitoTimer aTimer, const GameInputState &)
                 }
             }();
 
-            mAtlasToSprites
-                .at(visualSprite.atlas)
-                    .emplace_back(position,
-                                  visualSprite.sprite,
-                                  render::gSpriteOpacity,
-                                  visualSprite.mirroring);
+            if (body.theta == Radian{0.f})
+            {
+                mAtlasToSprites
+                    .at(visualSprite.atlas)
+                        .emplace_back(position,
+                                      visualSprite.sprite,
+                                      render::gSpriteOpacity,
+                                      visualSprite.mirroring);
+            }
+            else
+            {
+                auto modelTransform = 
+                    math::trans2d::rotateAbout(body.theta, body.massCenter)
+                    * math::trans2d::translate(position.as<math::Vec>()) 
+                    ;
+                mAtlasToSprites
+                    .at(visualSprite.atlas)
+                        .emplace_back(modelTransform,
+                                      visualSprite.sprite,
+                                      render::gSpriteOpacity,
+                                      visualSprite.mirroring);
+            }
         }
     }
 

--- a/src/app/grapkimbo/Systems/RenderWorld.h
+++ b/src/app/grapkimbo/Systems/RenderWorld.h
@@ -32,13 +32,13 @@ namespace ad {
 namespace grapito
 {
 
-typedef aunteater::Archetype<Position, VisualRectangle> RenderedRectangle;
-typedef aunteater::Archetype<Position, VisualPolygon> RenderedPolygon;
 typedef aunteater::Archetype<Position, Body, VisualRectangle> RenderedBodyRectangle;
 typedef aunteater::Archetype<Position, Body, VisualPolygon> RenderedBodyPolygon;
 typedef aunteater::Archetype<Position, VisualOutline> RenderedOutline;
 typedef aunteater::Archetype<Position, Body, PlayerData> AimVector;
-typedef aunteater::Archetype<Position, VisualSprite> RenderedSprite;
+typedef aunteater::Archetype<Position, VisualPolygon> RenderedPolygon;
+typedef aunteater::Archetype<Position, VisualRectangle> RenderedRectangle;
+typedef aunteater::Archetype<Body, Position, VisualSprite> RenderedSprite;
 
 class RenderWorld : public aunteater::System<GrapitoTimer, GameInputState>
 {

--- a/src/app/grapkimbo/Systems/Rules/CompetitionRule.h
+++ b/src/app/grapkimbo/Systems/Rules/CompetitionRule.h
@@ -114,7 +114,6 @@ private:
 };
 
 
-
 class CompetitionRule : public RuleBase
 {
     enum Phase

--- a/src/app/grapkimbo/Systems/SegmentStacker.cpp
+++ b/src/app/grapkimbo/Systems/SegmentStacker.cpp
@@ -60,7 +60,7 @@ void SegmentStacker::updateAvailableSegments(SegmentIndex aIndex)
         auto keptAlive = listConnected(aIndex, gKeptAliveSpan);
         if(std::find(keptAlive.begin(), keptAlive.end(), segmentIt->first) == keptAlive.end())
         {
-            ADLOG(info)("Removing segment {}", segmentIt->first);
+            ADLOG(debug)("Removing segment {}.", segmentIt->first);
             for(aunteater::weak_entity entity : segmentIt->second)
             {
                 entity->markToRemove(); 
@@ -76,7 +76,7 @@ void SegmentStacker::updateAvailableSegments(SegmentIndex aIndex)
     {
         if (addedId >= mStartingIndex && !mSegments.contains(addedId))
         {
-            ADLOG(info)("Adding segment {}", addedId);
+            ADLOG(debug)("Adding segment {}.", addedId);
             generateSegment(addedId);
         }
     }

--- a/src/app/grapkimbo/Systems/TransitionAnimationState.cpp
+++ b/src/app/grapkimbo/Systems/TransitionAnimationState.cpp
@@ -297,14 +297,14 @@ void TransitionAnimationState::updateDrawnFrames(const GrapitoTimer aTimer)
     {
         visualSprite.sprite = mAnimator.at(animatedSprite.animation,
                                            animatedSprite.advance(aTimer.delta()));
-        if (animatedSprite.horizontalMirroring)
+        if (animatedSprite.horizontalFlipping)
         {
-            visualSprite.mirroring.x() = -1;
+            visualSprite.mirroring |= graphics::Mirroring::FlipHorizontal;
             visualSprite.alignment = VisualSprite::AlignLeft;
         }
         else
         {
-            visualSprite.mirroring.x() = +1;
+            visualSprite.mirroring = graphics::Mirroring::None;
             visualSprite.alignment = VisualSprite::AlignRight;
         }
     }

--- a/src/app/grapkimbo/Systems/TransitionAnimationState.cpp
+++ b/src/app/grapkimbo/Systems/TransitionAnimationState.cpp
@@ -300,10 +300,12 @@ void TransitionAnimationState::updateDrawnFrames(const GrapitoTimer aTimer)
         if (animatedSprite.horizontalMirroring)
         {
             visualSprite.mirroring.x() = -1;
+            visualSprite.alignment = VisualSprite::AlignLeft;
         }
         else
         {
             visualSprite.mirroring.x() = +1;
+            visualSprite.alignment = VisualSprite::AlignRight;
         }
     }
 }

--- a/src/app/grapkimbo/Systems/TransitionAnimationState.cpp
+++ b/src/app/grapkimbo/Systems/TransitionAnimationState.cpp
@@ -17,6 +17,7 @@ namespace grapito {
 const StringId idleSid = handy::internalizeString("idle");
 const StringId runSid = handy::internalizeString("run");
 const StringId jumpSid = handy::internalizeString("jump");
+const StringId walledSid = handy::internalizeString("walled");
 
 
 enum class Mirroring
@@ -178,6 +179,14 @@ AnimationStateMachine makePlayerAnimationStateMachine(const graphics::sprite::An
             {
                 return PlayerAnimation::JumpRight;
             }
+            else if(isWalledLeft(aPlayerData))
+            {
+                return PlayerAnimation::WalledLeft;
+            }
+            else if(isWalledRight(aPlayerData))
+            {
+                return PlayerAnimation::WalledRight;
+            }
 
             return std::nullopt;
         }
@@ -202,6 +211,50 @@ AnimationStateMachine makePlayerAnimationStateMachine(const graphics::sprite::An
             else if(isGoingLeft(aAccelAndSpeed))
             {
                 return PlayerAnimation::JumpLeft;
+            }
+            else if(isWalledLeft(aPlayerData))
+            {
+                return PlayerAnimation::WalledLeft;
+            }
+            else if(isWalledRight(aPlayerData))
+            {
+                return PlayerAnimation::WalledRight;
+            }
+
+            return std::nullopt;
+        }
+    };
+
+    result.at(PlayerAnimation::WalledLeft) = {
+        makeLoopingAnimation(walledSid, aAnimator, Mirroring::Horizontal),
+        [](AnimatedSprite & aAnimation, const AccelAndSpeed & aAccelAndSpeed, const PlayerData & aPlayerData) 
+        -> std::optional<PlayerAnimation>
+        {
+            if (isGrounded(aPlayerData)) 
+            {
+                return PlayerAnimation::IdleLeft;
+            }
+            else if (!isWalledLeft(aPlayerData))
+            {
+                return PlayerAnimation::JumpLeft;
+            }
+
+            return std::nullopt;
+        }
+    };
+
+    result.at(PlayerAnimation::WalledRight) = {
+        makeLoopingAnimation(walledSid, aAnimator, Mirroring::None),
+        [](AnimatedSprite & aAnimation, const AccelAndSpeed & aAccelAndSpeed, const PlayerData & aPlayerData) 
+        -> std::optional<PlayerAnimation>
+        {
+            if (isGrounded(aPlayerData)) 
+            {
+                return PlayerAnimation::IdleRight;
+            }
+            else if (!isWalledRight(aPlayerData))
+            {
+                return PlayerAnimation::JumpRight;
             }
 
             return std::nullopt;

--- a/src/app/grapkimbo/TestScenes/CollisionTest.cpp
+++ b/src/app/grapkimbo/TestScenes/CollisionTest.cpp
@@ -19,6 +19,8 @@
 #include <Components/Position.h>
 #include <Components/VisualRectangle.h>
 
+#include <Context/Context.h>
+
 #include <aunteater/UpdateTiming.h>
 #include <aunteater/Entity.h>
 
@@ -72,7 +74,7 @@ CollisionTest::CollisionTest(graphics::ApplicationGlfw & aApplication, DebugUI &
     mUI{aUI}
 {
     mSystemManager.add<Gravity>();
-    mSystemManager.add<Control>();
+    mSystemManager.add<Control>(std::make_shared<Context>(""));
     mSystemManager.add<AccelSolver>();
     mSystemManager.add<Physics>();
     mSystemManager.add<RenderWorld>(aApplication.getAppInterface());  

--- a/src/app/grapkimbo/TestScenes/DistanceTest.cpp
+++ b/src/app/grapkimbo/TestScenes/DistanceTest.cpp
@@ -20,6 +20,8 @@
 #include "../Components/VisualRectangle.h"
 #include "../Components/DistanceJoint.h"
 
+#include "../Context/Context.h"
+
 #include <aunteater/UpdateTiming.h>
 #include <aunteater/Entity.h>
 
@@ -93,7 +95,7 @@ DistanceTest::DistanceTest(graphics::ApplicationGlfw & aApplication, DebugUI & a
     mUI{aUI}
 {
     mSystemManager.add<Gravity>();
-    mSystemManager.add<Control>();
+    mSystemManager.add<Control>(std::make_shared<Context>(""));
     mSystemManager.add<AccelSolver>();
     mSystemManager.add<Physics>();
     mSystemManager.add<RenderWorld>(aApplication.getAppInterface()); 

--- a/src/app/grapkimbo/TestScenes/FrictionTest.cpp
+++ b/src/app/grapkimbo/TestScenes/FrictionTest.cpp
@@ -19,6 +19,8 @@
 #include <Components/Position.h>
 #include <Components/VisualRectangle.h>
 
+#include "Context/Context.h"
+
 #include <aunteater/UpdateTiming.h>
 #include <aunteater/Entity.h>
 
@@ -66,7 +68,7 @@ FrictionTest::FrictionTest(graphics::ApplicationGlfw & aApplication, DebugUI & a
     mUI{aUI}
 {
     mSystemManager.add<Gravity>();
-    mSystemManager.add<Control>();
+    mSystemManager.add<Control>(std::make_shared<Context>(""));
     mSystemManager.add<AccelSolver>();
     mSystemManager.add<Physics>();
     mSystemManager.add<RenderWorld>(aApplication.getAppInterface());  

--- a/src/app/grapkimbo/TestScenes/PivotTest.cpp
+++ b/src/app/grapkimbo/TestScenes/PivotTest.cpp
@@ -19,6 +19,8 @@
 #include <Components/Position.h>
 #include "Components/VisualRectangle.h"
 
+#include "Context/Context.h"
+
 #include <aunteater/UpdateTiming.h>
 #include <aunteater/Entity.h>
 
@@ -77,7 +79,7 @@ PivotTest::PivotTest(graphics::ApplicationGlfw & aApplication, DebugUI & aUI) :
     mUI{aUI}
 {
     mSystemManager.add<Gravity>();
-    mSystemManager.add<Control>();
+    mSystemManager.add<Control>(std::make_shared<Context>(""));
     mSystemManager.add<AccelSolver>();
     mSystemManager.add<Physics>();
     mSystemManager.add<RenderWorld>(aApplication.getAppInterface());  

--- a/src/app/grapkimbo/TestScenes/SetPositionTest.cpp
+++ b/src/app/grapkimbo/TestScenes/SetPositionTest.cpp
@@ -21,6 +21,8 @@
 #include <Components/Position.h>
 #include "Components/VisualRectangle.h"
 
+#include "Context/Context.h"
+
 #include <aunteater/UpdateTiming.h>
 #include <aunteater/Entity.h>
 

--- a/src/app/grapkimbo/TestScenes/SimpleCollisionTest.cpp
+++ b/src/app/grapkimbo/TestScenes/SimpleCollisionTest.cpp
@@ -21,6 +21,8 @@
 #include <Components/Position.h>
 #include "Components/VisualRectangle.h"
 
+#include "Context/Context.h"
+
 #include <aunteater/UpdateTiming.h>
 #include <aunteater/Entity.h>
 
@@ -79,7 +81,7 @@ SimpleCollisionTest::SimpleCollisionTest(graphics::ApplicationGlfw & aApplicatio
     mUI{aUI}
 {
     mSystemManager.add<Gravity>();
-    mSystemManager.add<Control>();
+    mSystemManager.add<Control>(std::make_shared<Context>(""));
     mSystemManager.add<AccelSolver>();
     mSystemManager.add<Physics>();
     mSystemManager.add<RenderWorld>(aApplication.getAppInterface());  

--- a/src/app/grapkimbo/TestScenes/WeldTest.cpp
+++ b/src/app/grapkimbo/TestScenes/WeldTest.cpp
@@ -20,6 +20,8 @@
 #include "../Components/VisualRectangle.h"
 #include "../Components/WeldJoint.h"
 
+#include "Context/Context.h"
+
 #include <aunteater/UpdateTiming.h>
 #include <aunteater/Entity.h>
 
@@ -81,7 +83,7 @@ WeldTest::WeldTest(graphics::ApplicationGlfw & aApplication, DebugUI & aUI) :
     mUI{aUI}
 {
     mSystemManager.add<Gravity>();
-    mSystemManager.add<Control>();
+    mSystemManager.add<Control>(std::make_shared<Context>(""));
     mSystemManager.add<AccelSolver>();
     mSystemManager.add<Physics>();
     mSystemManager.add<RenderWorld>(aApplication.getAppInterface());

--- a/src/app/grapkimbo/Utils/Player.h
+++ b/src/app/grapkimbo/Utils/Player.h
@@ -45,6 +45,18 @@ inline bool isJumping(const PlayerData & aPlayerData)
 }
 
 
+inline bool isWalledLeft(const PlayerData & aPlayerData)
+{
+    return aPlayerData.state & PlayerCollisionState_WalledLeft;
+}
+
+
+inline bool isWalledRight(const PlayerData & aPlayerData)
+{
+    return aPlayerData.state & PlayerCollisionState_WalledRight;
+}
+
+
 inline bool isGrappleOut(const PlayerData & aPlayerData)
 {
     return aPlayerData.controlState & (ControlState_Attached | ControlState_Throwing);

--- a/src/app/grapkimbo/Utils/Player.h
+++ b/src/app/grapkimbo/Utils/Player.h
@@ -39,6 +39,12 @@ inline bool isGrounded(const PlayerData & aPlayerData)
 }
 
 
+inline bool isJumping(const PlayerData & aPlayerData)
+{
+    return aPlayerData.state & PlayerCollisionState_Jumping;
+}
+
+
 inline bool isGrappleOut(const PlayerData & aPlayerData)
 {
     return aPlayerData.controlState & (ControlState_Attached | ControlState_Throwing);

--- a/src/app/grapkimbo/commons.h
+++ b/src/app/grapkimbo/commons.h
@@ -4,6 +4,7 @@
 #include <handy/StringId.h>
 #include <sounds/SoundManager.h>
 
+#include <math/Angle.h>
 #include <math/Rectangle.h>
 #include <math/Vector.h>
 
@@ -19,6 +20,7 @@ using Position3 = math::Position<3, float>;
 using Size2 = math::Size<2, float>;
 using Size3 = math::Size<3, float>;
 using Rectangle = math::Rectangle<float>;
+using Radian = math::Radian<float>;
 
 struct Context;
 


### PR DESCRIPTION
closes #136

- Integrate jump animation.
- Integrate walled animation.
- Implement control of sprite alignment within the entity's bounding box.
- Use a grapple image as the grapple sprite. No rotation implemented.
- Adapt logging: lower segmen level, log player removed from context.
- Rotate grapple sprite to match orientation.
- Adapt to the new Spriting::Instance mirroring API.
- Change the rope color, and remove the visual rectangles for segments.
- [conan] Update graphics reference.
